### PR TITLE
✨ [FEAT] #15: 라벨 수정 및 삭제 API 작성

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -25,7 +25,7 @@ public enum ErrorStatus {
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
 
     // 라벨 관련 에러
-
+    LABEL_NOT_FOUND(HttpStatus.BAD_REQUEST, "LABEL4001", "해당 라벨이 존재하지 않습니다."),
     LABEL_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "LABEL4002", "라벨 이름은 최대 20자까지 가능합니다."),
     INVALID_COLOR(HttpStatus.BAD_REQUEST, "LABEL4003", "유효하지 않은 라벨 색상입니다.");
 

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -21,4 +21,12 @@ public class LabelRestController {
         LabelResponseDTO.CreateResultDto response = labelCommandService.createLabel(request);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
+
+    @PatchMapping("/{labelId}")
+    public ResponseEntity<ApiResponse> updateLabel(
+            @PathVariable Long labelId,
+            @RequestBody @Valid LabelRequestDTO.CreateDto request) {
+        LabelResponseDTO.CreateResultDto response = labelCommandService.updateLabel(labelId, request);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -6,6 +6,7 @@ import com.edison.project.domain.label.dto.LabelRequestDTO;
 import com.edison.project.domain.label.dto.LabelResponseDTO;
 import com.edison.project.domain.label.service.LabelCommandService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -28,5 +29,12 @@ public class LabelRestController {
             @RequestBody @Valid LabelRequestDTO.CreateDto request) {
         LabelResponseDTO.CreateResultDto response = labelCommandService.updateLabel(labelId, request);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+    @DeleteMapping("/{labelId}")
+    public ResponseEntity<ApiResponse> deleteLabel(@PathVariable @NotNull Long labelId) {
+        labelCommandService.deleteLabel(labelId);
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+
     }
 }

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -32,8 +32,10 @@ public class LabelRestController {
     }
 
     @DeleteMapping("/{labelId}")
-    public ResponseEntity<ApiResponse> deleteLabel(@PathVariable @NotNull Long labelId) {
-        labelCommandService.deleteLabel(labelId);
+    public ResponseEntity<ApiResponse> deleteLabel(
+            @PathVariable @NotNull Long labelId,
+            @RequestBody @Valid LabelRequestDTO.DeleteDto request) {
+        labelCommandService.deleteLabel(labelId, request.getMemberId());
         return ApiResponse.onSuccess(SuccessStatus._OK);
 
     }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
@@ -21,4 +21,13 @@ public class LabelRequestDTO {
         @NotBlank(message = "(DTO)라벨 색상은 필수입니다.")
         private String color;
     }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DeleteDto {
+        @NotNull(message = "(DTO)유저 ID는 필수입니다.")
+        private Long memberId;
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/label/entity/Label.java
+++ b/project/src/main/java/com/edison/project/domain/label/entity/Label.java
@@ -9,7 +9,7 @@ import lombok.*;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class Label extends BaseEntity {
 
     @Id

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandService.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandService.java
@@ -6,4 +6,5 @@ import com.edison.project.domain.label.dto.LabelRequestDTO;
 public interface LabelCommandService {
     LabelResponseDTO.CreateResultDto createLabel(LabelRequestDTO.CreateDto request);
     LabelResponseDTO.CreateResultDto updateLabel(Long labelId, LabelRequestDTO.CreateDto request);
+    void deleteLabel(Long labelId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandService.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandService.java
@@ -5,4 +5,5 @@ import com.edison.project.domain.label.dto.LabelRequestDTO;
 
 public interface LabelCommandService {
     LabelResponseDTO.CreateResultDto createLabel(LabelRequestDTO.CreateDto request);
+    LabelResponseDTO.CreateResultDto updateLabel(Long labelId, LabelRequestDTO.CreateDto request);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandService.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandService.java
@@ -6,5 +6,5 @@ import com.edison.project.domain.label.dto.LabelRequestDTO;
 public interface LabelCommandService {
     LabelResponseDTO.CreateResultDto createLabel(LabelRequestDTO.CreateDto request);
     LabelResponseDTO.CreateResultDto updateLabel(Long labelId, LabelRequestDTO.CreateDto request);
-    void deleteLabel(Long labelId);
+    void deleteLabel(Long labelId, Long memberId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
@@ -46,4 +46,37 @@ public class LabelCommandServiceImpl implements LabelCommandService {
                 .color(savedLabel.getColor().name())
                 .build();
     }
+
+    @Override
+    @Transactional
+    public LabelResponseDTO.CreateResultDto updateLabel(Long labelId, LabelRequestDTO.CreateDto request) {
+        Label label = labelRepository.findById(labelId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.LABEL_NOT_FOUND));
+
+        // **중복: 라벨 이름 길이 검증
+        if (request.getName().length() > 20) {
+            throw new GeneralException(ErrorStatus.LABEL_NAME_TOO_LONG);
+        }
+
+        // **중복: 라벨 색상 Enum 값 검증
+        try {
+            Label.LabelColor.valueOf(request.getColor());
+        } catch (IllegalArgumentException e) {
+            throw new GeneralException(ErrorStatus.INVALID_COLOR);
+        }
+
+        Label updatedLabel = label.toBuilder()
+                .name(request.getName())
+                .color(Label.LabelColor.valueOf(request.getColor()))
+                .build();
+
+        labelRepository.save(updatedLabel);
+
+        // **중복
+        return LabelResponseDTO.CreateResultDto.builder()
+                .id(updatedLabel.getLabelId())
+                .name(updatedLabel.getName())
+                .color(updatedLabel.getColor().name())
+                .build();
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
@@ -79,4 +79,13 @@ public class LabelCommandServiceImpl implements LabelCommandService {
                 .color(updatedLabel.getColor().name())
                 .build();
     }
+
+    @Override
+    @Transactional
+    public void deleteLabel(Long labelId) {
+        Label label = labelRepository.findById(labelId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.LABEL_NOT_FOUND));
+
+        labelRepository.deleteById(label.getLabelId());
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
@@ -88,9 +88,14 @@ public class LabelCommandServiceImpl implements LabelCommandService {
 
     @Override
     @Transactional
-    public void deleteLabel(Long labelId) {
+    public void deleteLabel(Long labelId, Long memberId) {
         Label label = labelRepository.findById(labelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LABELS_NOT_FOUND));
+
+        // 삭제 권한 확인
+        if (!label.getMember().getMemberId().equals(memberId)) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
 
         labelRepository.deleteById(label.getLabelId());
     }

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=project
 
 # MySQL Database Connection
-spring.datasource.url=jdbc:mysql://localhost:3306/edison?useSSL=false&serverTimezone=UTC
+spring.datasource.url=jdbc:mysql://localhost:3306/edison_db?useSSL=false&serverTimezone=UTC
 spring.datasource.username=root
-spring.datasource.password=tjsgh1210
+spring.datasource.password=gksmf0329
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 
 # Hibernate Configuration


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #15

## 📝 작업 내용

1. 라벨 수정 API를 구현하였습니다.
- validation 내용은 동일, 유효하지 않은 라벨 id로 접근하는 경우에 대해서만 추가로 처리해줌
<img width="879" alt="image" src="https://github.com/user-attachments/assets/53bec0a8-de8c-4bb8-a688-c3f18a27cde9" />

2. 라벨 삭제 API를 구현하였습니다.
- 수정 로직과 거의 90퍼 일치... 할 게 없었어요..

**_service 단에 중복코드 많은데, 전에꺼랑 충돌 일어나면 해결하기 까다로울까바 일단 이렇게 PR 날립니다! 요거 develop에 머지한 후 추가로 리팩토링 할 예정입니다,,_**

### 📸 포스트맨 테스트 스크린샷
<img width="417" alt="image" src="https://github.com/user-attachments/assets/6cf43bbf-a1c3-4c3c-ac9c-5d6e4fc5c262" />
<img width="420" alt="image" src="https://github.com/user-attachments/assets/6a2ed122-2e00-4b54-a993-e0f369995a36" />
<img width="410" alt="image" src="https://github.com/user-attachments/assets/bb2c562b-be72-4bad-8938-270675c9cfeb" />


## 💬 리뷰 요구사항(선택)

> 테스트 가능하면 테스트 해주시고, validation 빠진 부분 있는지 체크 부탁드립니다! 
그리고.. .idea 빼고 push된 거 같긴한데, 긴가민가해서 맞는지 확인해주세요 ... 
> 테스트 할 API:
> 1. PATCH, /labels/라벨아이디값
>  {
    "name": "",
    "color": ""
}
> 2. DELETE, /labels/라벨아이디값

