### PR TITLE
✨ [FEAT] #25: 라벨 목록 조회 API 작성

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
@@ -2,14 +2,7 @@ package com.edison.project.domain.bubble.repository;
 
 import com.edison.project.domain.bubble.entity.BubbleLabel;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
-import java.util.List;
 
 public interface BubbleLabelRepository extends JpaRepository<BubbleLabel, Long> {
-    // 라벨별로 버블의 개수를 가져오는 쿼리
-    @Query("SELECT bl.label, COUNT(bl.bubble) FROM BubbleLabel bl " +
-            "WHERE bl.label.member.memberId = :memberId " +
-            "GROUP BY bl.label")
-    List<Object[]> findBubbleCountsByMemberId(@Param("memberId") Long memberId);
+
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
@@ -2,10 +2,14 @@ package com.edison.project.domain.bubble.repository;
 
 import com.edison.project.domain.bubble.entity.BubbleLabel;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.transaction.annotation.Transactional;
-
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface BubbleLabelRepository extends JpaRepository<BubbleLabel, Long> {
-
+    // 라벨별로 버블의 개수를 가져오는 쿼리
+    @Query("SELECT bl.label, COUNT(bl.bubble) FROM BubbleLabel bl " +
+            "WHERE bl.label.member.memberId = :memberId " +
+            "GROUP BY bl.label")
+    List<Object[]> findBubbleCountsByMemberId(@Param("memberId") Long memberId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -5,17 +5,21 @@ import com.edison.project.common.status.SuccessStatus;
 import com.edison.project.domain.label.dto.LabelRequestDTO;
 import com.edison.project.domain.label.dto.LabelResponseDTO;
 import com.edison.project.domain.label.service.LabelCommandService;
+import com.edison.project.domain.label.service.LabelQueryService;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @RestController
 @RequestMapping("/labels")
 @RequiredArgsConstructor
 public class LabelRestController {
     private final LabelCommandService labelCommandService;
+    private final LabelQueryService labelQueryService;
 
     @PostMapping
     public ResponseEntity<ApiResponse> createLabel(@RequestBody @Valid LabelRequestDTO.CreateDto request) {
@@ -38,5 +42,12 @@ public class LabelRestController {
         labelCommandService.deleteLabel(labelId, request.getMemberId());
         return ApiResponse.onSuccess(SuccessStatus._OK);
 
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse> getLabelsWithBubbleCounts(
+            @RequestParam(name = "memberId") Long memberId) {
+        List<LabelResponseDTO.ListResultDto> labels = labelQueryService.getLabelListByMemberId(memberId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, labels);
     }
 }

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -45,9 +45,9 @@ public class LabelRestController {
     }
 
     @GetMapping
-    public ResponseEntity<ApiResponse> getLabelsWithBubbleCounts(
+    public ResponseEntity<ApiResponse> getLabelList(
             @RequestParam(name = "memberId") Long memberId) {
-        List<LabelResponseDTO.ListResultDto> labels = labelQueryService.getLabelListByMemberId(memberId);
+        List<LabelResponseDTO.ListResultDto> labels = labelQueryService.getLabelInfoList(memberId);
         return ApiResponse.onSuccess(SuccessStatus._OK, labels);
     }
 }

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -10,6 +10,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -17,6 +18,7 @@ import java.util.List;
 @RestController
 @RequestMapping("/labels")
 @RequiredArgsConstructor
+@Validated
 public class LabelRestController {
     private final LabelCommandService labelCommandService;
     private final LabelQueryService labelQueryService;
@@ -46,7 +48,7 @@ public class LabelRestController {
 
     @GetMapping
     public ResponseEntity<ApiResponse> getLabelList(
-            @RequestParam(name = "memberId") Long memberId) {
+            @RequestParam Long memberId) {
         List<LabelResponseDTO.ListResultDto> labels = labelQueryService.getLabelInfoList(memberId);
         return ApiResponse.onSuccess(SuccessStatus._OK, labels);
     }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
@@ -27,6 +27,7 @@ public class LabelRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DeleteDto {
+
         // @NotNull(message = "(DTO)유저 ID는 필수입니다.")
         private Long memberId;
     }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
@@ -27,7 +27,8 @@ public class LabelRequestDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DeleteDto {
-        @NotNull(message = "(DTO)유저 ID는 필수입니다.")
+        // @NotNull(message = "(DTO)유저 ID는 필수입니다.")
         private Long memberId;
     }
+
 }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -13,4 +13,15 @@ public class LabelResponseDTO {
         private String name;
         private String color;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ListResultDto {
+        private Long labelId;
+        private String name;
+        private String color;
+        private Long bubbleCount;
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -3,6 +3,9 @@ package com.edison.project.domain.label.repository;
 import com.edison.project.domain.label.entity.Label;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LabelRepository extends JpaRepository<Label, Long> {
-    // 추가 쿼리 메서드는 여기 작성
+    // 특정 사용자의 모든 라벨 조회(라벨만 있고 그 안에 버블 없는 경우를 위해)
+    List<Label> findByMember_MemberId(Long memberId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -2,10 +2,18 @@ package com.edison.project.domain.label.repository;
 
 import com.edison.project.domain.label.entity.Label;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface LabelRepository extends JpaRepository<Label, Long> {
-    // 특정 사용자의 모든 라벨 조회(라벨만 있고 그 안에 버블 없는 경우를 위해)
-    List<Label> findByMember_MemberId(Long memberId);
+
+    // 특정 사용자의 모든 라벨 정보와 & 라벨별 버블 개수 조회
+    @Query("SELECT l, COUNT(bl.bubble) " +
+            "FROM Label l " +
+            "LEFT JOIN BubbleLabel bl ON l.labelId = bl.label.labelId AND bl.bubble.isDeleted = false " +
+            "WHERE l.member.memberId = :memberId " +
+            "GROUP BY l")
+    List<Object[]> findLabelInfoByMemberId(@Param("memberId") Long memberId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryService.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryService.java
@@ -2,6 +2,7 @@ package com.edison.project.domain.label.service;
 
 import java.util.List;
 import com.edison.project.domain.label.dto.LabelResponseDTO;
+
 public interface LabelQueryService {
-    List<LabelResponseDTO.ListResultDto> getLabelListByMemberId(Long memberId);
+    List<LabelResponseDTO.ListResultDto> getLabelInfoList(Long memberId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryService.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryService.java
@@ -1,0 +1,7 @@
+package com.edison.project.domain.label.service;
+
+import java.util.List;
+import com.edison.project.domain.label.dto.LabelResponseDTO;
+public interface LabelQueryService {
+    List<LabelResponseDTO.ListResultDto> getLabelListByMemberId(Long memberId);
+}

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -22,9 +22,9 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
     @Override
     public List<LabelResponseDTO.ListResultDto> getLabelInfoList(Long memberId) {
-
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        if (!memberRepository.existsById(memberId)) {
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+        }
 
 //        사용자에 null값이 들어갈 수 없는 경우, 주석 해제할 것
 //        if (memberId == null) {

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -1,0 +1,56 @@
+package com.edison.project.domain.label.service;
+
+import com.edison.project.domain.label.dto.LabelResponseDTO;
+import com.edison.project.domain.label.entity.Label;
+import com.edison.project.domain.bubble.repository.BubbleLabelRepository;
+import com.edison.project.domain.label.repository.LabelRepository;
+import com.edison.project.common.exception.GeneralException;
+import com.edison.project.common.status.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class LabelQueryServiceImpl implements LabelQueryService {
+    private final LabelRepository labelRepository;
+    private final BubbleLabelRepository bubbleLabelRepository;
+
+    @Override
+    public List<LabelResponseDTO.ListResultDto> getLabelListByMemberId(Long memberId) {
+
+//        사용자에 null값이 들어갈 수 없는 경우, 주석 해제할 것
+//        if (memberId == null) {
+//            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+//        }
+
+        // 1. (특정 멤버의) 모든 라벨을 조회
+        List<Label> labels = labelRepository.findByMember_MemberId(memberId);
+
+        // 2. 라벨별 버블 개수를 조회
+        List<Object[]> labelWithBubbleCounts = bubbleLabelRepository.findBubbleCountsByMemberId(memberId);
+
+        // 3. 라벨(ID)과 버블 개수를 맵핑
+        Map<Long, Long> bubbleCountMap = labelWithBubbleCounts.stream()
+                .collect(Collectors.toMap(
+                        result -> ((Label) result[0]).getLabelId(),
+                        result -> (Long) result[1]
+                ));
+
+        // 4. 모든 라벨에 대한 정보 출력
+        return labels.stream()
+                .map(label -> LabelResponseDTO.ListResultDto.builder()
+                        .labelId(label.getLabelId())
+                        .name(label.getName())
+                        .color(label.getColor().name())
+                        // 버블 없는 라벨에 대해 bubbleCount가 null이 아니라 0으로 뜨도록 설정
+                        .bubbleCount(bubbleCountMap.getOrDefault(label.getLabelId(), 0L))
+                        .build())
+                .collect(Collectors.toList());
+
+    }
+}

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -6,50 +6,44 @@ import com.edison.project.domain.bubble.repository.BubbleLabelRepository;
 import com.edison.project.domain.label.repository.LabelRepository;
 import com.edison.project.common.exception.GeneralException;
 import com.edison.project.common.status.ErrorStatus;
+import com.edison.project.domain.member.entity.Member;
+import com.edison.project.domain.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class LabelQueryServiceImpl implements LabelQueryService {
     private final LabelRepository labelRepository;
-    private final BubbleLabelRepository bubbleLabelRepository;
+    private final MemberRepository memberRepository;
 
     @Override
-    public List<LabelResponseDTO.ListResultDto> getLabelListByMemberId(Long memberId) {
+    public List<LabelResponseDTO.ListResultDto> getLabelInfoList(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
 //        사용자에 null값이 들어갈 수 없는 경우, 주석 해제할 것
 //        if (memberId == null) {
 //            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
 //        }
 
-        // 1. (특정 멤버의) 모든 라벨을 조회
-        List<Label> labels = labelRepository.findByMember_MemberId(memberId);
+        List<Object[]> labelInfoList = labelRepository.findLabelInfoByMemberId(memberId);
 
-        // 2. 라벨별 버블 개수를 조회
-        List<Object[]> labelWithBubbleCounts = bubbleLabelRepository.findBubbleCountsByMemberId(memberId);
-
-        // 3. 라벨(ID)과 버블 개수를 맵핑
-        Map<Long, Long> bubbleCountMap = labelWithBubbleCounts.stream()
-                .collect(Collectors.toMap(
-                        result -> ((Label) result[0]).getLabelId(),
-                        result -> (Long) result[1]
-                ));
-
-        // 4. 모든 라벨에 대한 정보 출력
-        return labels.stream()
-                .map(label -> LabelResponseDTO.ListResultDto.builder()
-                        .labelId(label.getLabelId())
-                        .name(label.getName())
-                        .color(label.getColor().name())
-                        // 버블 없는 라벨에 대해 bubbleCount가 null이 아니라 0으로 뜨도록 설정
-                        .bubbleCount(bubbleCountMap.getOrDefault(label.getLabelId(), 0L))
-                        .build())
+        return labelInfoList.stream()
+                .map(result -> {
+                    Label label = (Label) result[0];
+                    Long bubbleCount = (Long) result[1];
+                    return LabelResponseDTO.ListResultDto.builder()
+                            .labelId(label.getLabelId())
+                            .name(label.getName())
+                            .color(label.getColor().name())
+                            .bubbleCount(bubbleCount != null ? bubbleCount : 0L) // 버블 없는 라벨은 0으로 처리
+                            .build();
+                })
                 .collect(Collectors.toList());
 
     }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #25 

## 📝 작업 내용

> 라벨 목록 조회 API를 구현하였습니다.
- bubbleCount 조회를 위해 JPQL 사용
<img width="886" alt="image" src="https://github.com/user-attachments/assets/a8a8a9d3-7b7e-4075-9875-0c2e2486bd5e" />

- 버블 없는 라벨의 bubbleCount값은 일단 null이 아니라 0으로 처리되도록 함
- validation : 유효하지 않은 memberId로 요청한 경우에 대해서만 처리함 (삭제나 수정이 아닌 조회여서, 일단 권한 관련 검증은 안했습니다)

### 📸 포스트맨 테스트 스크린샷
<img width="930" alt="image" src="https://github.com/user-attachments/assets/55015566-308e-4b5b-a79a-5e00fbae670f" />
<img width="644" alt="image" src="https://github.com/user-attachments/assets/6c2674df-a612-4b49-a29b-3d5780e2823f" />
<img width="511" alt="image" src="https://github.com/user-attachments/assets/4a6513d0-19dc-411b-9ff3-9151fe32bf5e" />


## 💬 리뷰 요구사항(선택)

> 아래 내용 중점으로 잘 돌아가는지 테스트 부탁드립니다!
[ GET, /labels?memberId= ]
1. 버블 없는 라벨은 count값 0으로 잘 뜨는지
2. 삭제(soft_delete)된 버블은 카운트에 추가되지 않는지
3. 복원된 버블은 카운트에 추가되는지

