### PR TITLE
✨ [FEAT] #27: 라벨 상세 조회 API 작성

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
@@ -1,8 +1,20 @@
 package com.edison.project.domain.bubble.repository;
 
+import com.edison.project.domain.bubble.entity.Bubble;
 import com.edison.project.domain.bubble.entity.BubbleLabel;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface BubbleLabelRepository extends JpaRepository<BubbleLabel, Long> {
+
+    // 특정 라벨에 연결된 모든 버블(삭제되지 않은) 조회
+    @Query("SELECT b " +
+            "FROM BubbleLabel bl " +
+            "JOIN bl.bubble b " +
+            "WHERE bl.label.labelId = :labelId AND b.isDeleted = false")
+    List<Bubble> findBubblesByLabelId(@Param("labelId") Long labelId);
 
 }

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -39,7 +39,7 @@ public class LabelRestController {
 
     @DeleteMapping("/{labelId}")
     public ResponseEntity<ApiResponse> deleteLabel(
-            @PathVariable @NotNull Long labelId,
+            @PathVariable Long labelId,
             @RequestBody @Valid LabelRequestDTO.DeleteDto request) {
         labelCommandService.deleteLabel(labelId, request.getMemberId());
         return ApiResponse.onSuccess(SuccessStatus._OK);
@@ -52,4 +52,13 @@ public class LabelRestController {
         List<LabelResponseDTO.ListResultDto> labels = labelQueryService.getLabelInfoList(memberId);
         return ApiResponse.onSuccess(SuccessStatus._OK, labels);
     }
+
+    @GetMapping("/{labelId}")
+    public ResponseEntity<ApiResponse> getLabelDetail(
+            @PathVariable Long labelId,
+            @RequestParam Long memberId) {
+        LabelResponseDTO.DetailResultDto details = labelQueryService.getLabelDetailInfoList(memberId, labelId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, details);
+    }
+
 }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -1,6 +1,9 @@
 package com.edison.project.domain.label.dto;
 
+import com.edison.project.domain.bubble.dto.BubbleResponseDto;
 import lombok.*;
+
+import java.util.List;
 
 public class LabelResponseDTO {
 
@@ -23,5 +26,17 @@ public class LabelResponseDTO {
         private String name;
         private String color;
         private Long bubbleCount;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DetailResultDto {
+        private Long labelId;
+        private String name;
+        private String color;
+        private Long bubbleCount;
+        private List<BubbleResponseDto.CreateResultDto> bubbles;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryService.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryService.java
@@ -5,4 +5,5 @@ import com.edison.project.domain.label.dto.LabelResponseDTO;
 
 public interface LabelQueryService {
     List<LabelResponseDTO.ListResultDto> getLabelInfoList(Long memberId);
+    LabelResponseDTO.DetailResultDto getLabelDetailInfoList(Long memberId, Long labelId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -56,6 +56,11 @@ public class LabelQueryServiceImpl implements LabelQueryService {
         Label label = labelRepository.findById(labelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LABELS_NOT_FOUND));
 
+        // 요청한 라벨이 memberId에 속해 있는지(해당 사용자가 만든 라벨이 맞는지) 검증
+        if (!label.getMember().getMemberId().equals(memberId)) {
+            throw new GeneralException(ErrorStatus._UNAUTHORIZED);
+        }
+
         List<Bubble> bubbles = bubbleLabelRepository.findBubblesByLabelId(labelId);
 
         // BubbleDetailDto 변환


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #27 

## 📝 작업 내용

> 라벨 상세내용 조회 API를 구현하였습니다.
- 라벨에 연결된 버블 내용 조회를 위해 bubblelabelrepo에 JPQL 사용
<img width="678" alt="image" src="https://github.com/user-attachments/assets/78f4f143-e99e-4613-b859-da90b77e3d98" />

- 서비스 단 내부에 mapping 관련 긴 코드 있는데, 버블 조회 api 구현에 따라 나중에 중복 제거할 수 있을 것 같아 일단은 냅뒀습니다!(나중에 리팩토링할게요..)

- validation 
1. 유효하지 않은 memberId로 요청한 경우
2. 유효하지 않은(=없는) labelId로 요청한 경우
3. 권한 없는 labelId(=본인이 만든게 아닌 라벨)을 요청한 경우


### 📸 스크린샷
<img width="726" alt="image" src="https://github.com/user-attachments/assets/7ffbae80-3a3e-4910-b651-46084d82abbd" />

<img width="489" alt="image" src="https://github.com/user-attachments/assets/8eb7eff0-0789-4152-8dfd-eeaa86952eb3" />

<img width="482" alt="image" src="https://github.com/user-attachments/assets/a63d192d-4402-4faf-8826-7d74dde07e87" />


## 💬 리뷰 요구사항(선택)

>1. 기능 잘 돌아가는지
>2. 위의 validation 잘 처리되는지
>3. 이외에 검증할 사항 없을지
>확인 부탁드립니다!! (쿼리나 path변수로 null들어오는 경우는 404나 500에러 떠서 일단 처리하지 않고 냅뒀어용)
