### PR TITLE
✨[FEAT] #32: 전체 버블 목록 조회 구현

### DIFF
--- a/project/src/main/java/com/edison/project/common/response/ApiResponse.java
+++ b/project/src/main/java/com/edison/project/common/response/ApiResponse.java
@@ -7,11 +7,13 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.stereotype.Component;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Slice;
+
 
 @Getter
 @RequiredArgsConstructor
-@JsonPropertyOrder({"isSuccess", "code", "message", "result"})
+@JsonPropertyOrder({"isSuccess", "code", "message", "pageInfo", "result"})
 public class ApiResponse {
     private final Boolean isSuccess;
     private final String code;
@@ -41,16 +43,13 @@ public class ApiResponse {
         return onSuccess(status, null, result);
     }
 
-    /* 성공 - 페이지네이션에 대한 응답
-    public static ResponseEntity<ApiResponse> onSuccess(SuccessStatus status, Page page) {
-        PageInfo pageInfo = new PageInfo(page.getNumber(), page.getSize(), page.hasNext());
+    // 성공 - 페이지네이션 포함
+    public static ResponseEntity<ApiResponse> onSuccess(SuccessStatus status, Page<?> page) {
+        PageInfo pageInfo = new PageInfo(page.getNumber(), page.getSize(), page.hasNext(), page.getTotalElements(),
+                page.getTotalPages());
         return onSuccess(status, pageInfo, page.getContent());
     }
 
-    public static ResponseEntity<ApiResponse> onSuccess(SuccessStatus status, Slice<?> page) {
-        PageInfo pageInfo = new PageInfo(page.getNumber(), page.getSize(), page.hasNext());
-        return onSuccess(status, pageInfo, page.getContent());
-    }*/
 
     // 실패한 경우 응답 생성
     public static ResponseEntity<ApiResponse> onFailure(ErrorStatus error) {

--- a/project/src/main/java/com/edison/project/common/response/PageInfo.java
+++ b/project/src/main/java/com/edison/project/common/response/PageInfo.java
@@ -9,4 +9,6 @@ public class PageInfo {
     private Integer page;
     private Integer size;
     private Boolean hasNext;
+    private Long totalElements;
+    private Integer totalPages;
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -7,8 +7,13 @@ import com.edison.project.domain.bubble.dto.BubbleResponseDto;
 import com.edison.project.domain.bubble.service.BubbleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import org.springframework.data.domain.Pageable;
+
 
 @RestController
 @RequestMapping("/bubbles")
@@ -18,8 +23,8 @@ public class BubbleRestController {
 
     // 버블 생성
     @PostMapping
-    public ResponseEntity<ApiResponse> createBubble(@RequestBody @Valid BubbleRequestDto.CreateDto request) {
-        BubbleResponseDto.CreateResultDto response = bubbleService.createBubble(request);
+    public ResponseEntity<ApiResponse> createBubble(@RequestBody @Valid BubbleRequestDto.ListDto request) {
+        BubbleResponseDto.ListResultDto response = bubbleService.createBubble(request);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
@@ -41,5 +46,18 @@ public class BubbleRestController {
         request.setBubbleId(bubbleId);
         BubbleResponseDto.RestoreResultDto result = bubbleService.restoreBubble(request);
         return ApiResponse.onSuccess(SuccessStatus._OK, result);
+    }
+
+    // 버블 전체 목록 조회
+    @GetMapping
+    public ResponseEntity<ApiResponse> getBubblesByMember(
+            @RequestParam Long memberId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+
+        // 최신순 정렬
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        ResponseEntity<ApiResponse> response = bubbleService.getBubblesByMember(memberId, pageable);
+        return response;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -15,7 +15,7 @@ public class BubbleRequestDto {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreateDto {
+    public static class ListDto {
 
         private Long memberId;
         private String title;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -12,12 +12,12 @@ public class BubbleResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class CreateResultDto {
+    public static class ListResultDto {
         private Long bubbleId;
         private String title;
         private String content;
         private String mainImageUrl;
-        private Set<Long> labels;
+        private List<String> labels;
         private Long linkedBubbleId;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -1,6 +1,8 @@
 package com.edison.project.domain.bubble.repository;
 
 import com.edison.project.domain.bubble.entity.Bubble;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -14,5 +16,7 @@ public interface BubbleRepository extends JpaRepository<Bubble, Long> {
 
     // 휴지통에 있는 Bubble만 조회
     Optional<Bubble> findByBubbleIdAndIsDeletedTrue(Long bubbleId);
+
+    Page<Bubble> findByMember_MemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
 
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
@@ -1,10 +1,18 @@
 package com.edison.project.domain.bubble.service;
 
+import com.edison.project.common.response.ApiResponse;
 import com.edison.project.domain.bubble.dto.BubbleRequestDto;
 import com.edison.project.domain.bubble.dto.BubbleResponseDto;
+import com.edison.project.domain.bubble.entity.Bubble;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.data.domain.Pageable;
+import java.util.List;
 
 public interface BubbleService {
-    BubbleResponseDto.CreateResultDto createBubble(BubbleRequestDto.CreateDto requestDto);
+    BubbleResponseDto.ListResultDto createBubble(BubbleRequestDto.ListDto requestDto);
     BubbleResponseDto.DeleteResultDto deleteBubble(BubbleRequestDto.DeleteDto requestDto);
     BubbleResponseDto.RestoreResultDto restoreBubble(BubbleRequestDto.RestoreDto requestDto);
+
+    ResponseEntity<ApiResponse> getBubblesByMember(Long memberId, Pageable pageable);
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -1,7 +1,10 @@
 package com.edison.project.domain.bubble.service;
 
 import com.edison.project.common.exception.GeneralException;
+import com.edison.project.common.response.ApiResponse;
+import com.edison.project.common.response.PageInfo;
 import com.edison.project.common.status.ErrorStatus;
+import com.edison.project.common.status.SuccessStatus;
 import com.edison.project.domain.bubble.dto.BubbleRequestDto;
 import com.edison.project.domain.bubble.dto.BubbleResponseDto;
 import com.edison.project.domain.bubble.entity.Bubble;
@@ -15,10 +18,13 @@ import com.edison.project.domain.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 
+import org.springframework.data.domain.Pageable;
 import java.util.*;
-import java.util.stream.Collectors;
+        import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -32,7 +38,7 @@ public class BubbleServiceImpl implements BubbleService {
 
     @Override
     @Transactional
-    public BubbleResponseDto.CreateResultDto createBubble(BubbleRequestDto.CreateDto requestDto) {
+    public BubbleResponseDto.ListResultDto createBubble(BubbleRequestDto.ListDto requestDto) {
         // Member 조회
         Member member = memberRepository.findById(requestDto.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -70,12 +76,12 @@ public class BubbleServiceImpl implements BubbleService {
         savedBubble.getLabels().addAll(bubbleLabels);
 
         // ResponseDto 반환
-        return BubbleResponseDto.CreateResultDto.builder()
+        return BubbleResponseDto.ListResultDto.builder()
                 .bubbleId(savedBubble.getBubbleId())
                 .title(savedBubble.getTitle())
                 .content(savedBubble.getContent())
                 .mainImageUrl(savedBubble.getMainImg())
-                .labels(labelIds)
+                .labels(labels.stream().map(Label::getName).collect(Collectors.toList()))
                 .linkedBubbleId(Optional.ofNullable(linkedBubble).map(Bubble::getBubbleId).orElse(null))
                 .createdAt(savedBubble.getCreatedAt())
                 .updatedAt(savedBubble.getUpdatedAt())
@@ -125,6 +131,38 @@ public class BubbleServiceImpl implements BubbleService {
                 .bubbleId(bubble.getBubbleId())
                 .isRestored(!bubble.isDeleted())
                 .build();
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse> getBubblesByMember(Long memberId, Pageable pageable) {
+        // Member 조회
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberIdAndIsDeletedFalse(memberId, pageable);
+
+        PageInfo pageInfo = new PageInfo(bubblePage.getNumber(), bubblePage.getSize(), bubblePage.hasNext(),
+                bubblePage.getTotalElements(), bubblePage.getTotalPages());
+
+        // Bubble 데이터 변환
+        List<BubbleResponseDto.ListResultDto> bubbles = bubblePage.getContent().stream()
+                .map(bubble -> BubbleResponseDto.ListResultDto.builder()
+                        .bubbleId(bubble.getBubbleId())
+                        .title(bubble.getTitle())
+                        .content(bubble.getContent())
+                        .mainImageUrl(bubble.getMainImg())
+                        .labels(bubble.getLabels().stream()
+                                .map(label -> label.getLabel().getName())
+                                .collect(Collectors.toList()))
+                        .linkedBubbleId(Optional.ofNullable(bubble.getLinkedBubble())
+                                .map(Bubble::getBubbleId)
+                                .orElse(null))
+                        .createdAt(bubble.getCreatedAt())
+                        .updatedAt(bubble.getUpdatedAt())
+                        .build())
+                .collect(Collectors.toList());
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, pageInfo, bubbles);
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -37,6 +37,6 @@ public class LabelResponseDTO {
         private String name;
         private String color;
         private Long bubbleCount;
-        private List<BubbleResponseDto.CreateResultDto> bubbles;
+        private List<BubbleResponseDto.ListResultDto> bubbles;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -65,15 +65,15 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
         // BubbleDetailDto 변환
         //** map 내부의 함수 -> 버블 상세내용조회 api 구현 후 함수로 뽑아 중복 제거 가능
-        List<BubbleResponseDto.CreateResultDto> bubbleDetails = bubbles.stream()
-                .map(bubble -> BubbleResponseDto.CreateResultDto.builder()
+        List<BubbleResponseDto.ListResultDto> bubbleDetails = bubbles.stream()
+                .map(bubble -> BubbleResponseDto.ListResultDto.builder()
                         .bubbleId(bubble.getBubbleId())
                         .title(bubble.getTitle())
                         .content(bubble.getContent())
                         .mainImageUrl(bubble.getMainImg())
                         .labels(bubble.getLabels().stream()
-                                .map(bl -> bl.getLabel().getLabelId())
-                                .collect(Collectors.toSet()))
+                                .map(bl -> bl.getLabel().getName())
+                                .collect(Collectors.toList()))
                         .linkedBubbleId(bubble.getLinkedBubble() != null ? bubble.getLinkedBubble().getBubbleId() : null)
                         .createdAt(bubble.getCreatedAt())
                         .updatedAt(bubble.getUpdatedAt())


### PR DESCRIPTION

## #⃣ 연관된 이슈

> close #32 

## 📝 작업 내용

> 스페이스에서 전체 버블 목록을 조회하는 API를 구현하였습니다.
- 유저 검증
- 페이지네이션 적용, size = 20
- 최신순 정렬

### 📸 스크린샷 (선택)
- 성공 시
<img width="555" alt="image" src="https://github.com/user-attachments/assets/c4838433-17c6-47a9-a0b7-06d311682356" />

- 존재하지 않는 유저인 경우
<img width="523" alt="image" src="https://github.com/user-attachments/assets/b957cef9-d689-4338-abb3-d0f3e30a7a98" />

## 💬 리뷰 요구사항(선택)

