### PR TITLE
✨ [FEAT] #44: 버블 상세정보 조회 구현

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -49,7 +49,7 @@ public class BubbleRestController {
     }
 
     // 버블 전체 목록 조회
-    @GetMapping
+    @GetMapping("/space")
     public ResponseEntity<ApiResponse> getBubblesByMember(
             @RequestParam Long memberId,
             @RequestParam(defaultValue = "0") int page,
@@ -59,5 +59,12 @@ public class BubbleRestController {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         ResponseEntity<ApiResponse> response = bubbleService.getBubblesByMember(memberId, pageable);
         return response;
+    }
+
+    // 버블 상세정보 조회
+    @GetMapping("/{bubbleId}")
+    public ResponseEntity<ApiResponse> getBubble(@PathVariable Long bubbleId) {
+        BubbleResponseDto.ListResultDto response = bubbleService.getBubble(bubbleId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
@@ -3,11 +3,9 @@ package com.edison.project.domain.bubble.service;
 import com.edison.project.common.response.ApiResponse;
 import com.edison.project.domain.bubble.dto.BubbleRequestDto;
 import com.edison.project.domain.bubble.dto.BubbleResponseDto;
-import com.edison.project.domain.bubble.entity.Bubble;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.data.domain.Pageable;
-import java.util.List;
 
 public interface BubbleService {
     BubbleResponseDto.ListResultDto createBubble(BubbleRequestDto.ListDto requestDto);
@@ -15,4 +13,6 @@ public interface BubbleService {
     BubbleResponseDto.RestoreResultDto restoreBubble(BubbleRequestDto.RestoreDto requestDto);
 
     ResponseEntity<ApiResponse> getBubblesByMember(Long memberId, Pageable pageable);
+
+    BubbleResponseDto.ListResultDto getBubble(Long bubbleId);
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -165,4 +165,24 @@ public class BubbleServiceImpl implements BubbleService {
         return ApiResponse.onSuccess(SuccessStatus._OK, pageInfo, bubbles);
     }
 
+    @Override
+    public BubbleResponseDto.ListResultDto getBubble(Long bubbleId) {
+        Bubble bubble = bubbleRepository.findByBubbleIdAndIsDeletedFalse(bubbleId).orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
+
+        return BubbleResponseDto.ListResultDto.builder()
+                .bubbleId(bubble.getBubbleId())
+                .title(bubble.getTitle())
+                .content(bubble.getContent())
+                .mainImageUrl(bubble.getMainImg())
+                .labels(bubble.getLabels().stream()
+                        .map(label -> label.getLabel().getName())
+                        .collect(Collectors.toList()))
+                .linkedBubbleId(Optional.ofNullable(bubble.getLinkedBubble())
+                        .map(Bubble::getBubbleId)
+                        .orElse(null))
+                .createdAt(bubble.getCreatedAt())
+                .updatedAt(bubble.getUpdatedAt())
+                .build();
+    }
+
 }

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=project
 
 # MySQL Database Connection
-spring.datasource.url=jdbc:mysql://localhost:3306/edison_db?useSSL=false&serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://localhost:3306/edison?useSSL=false&serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=${DB_password}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## #⃣ 연관된 이슈

close #44 

## 📝 작업 내용

> 버블 아이디로 해당 버블의 상세정보를 조회하는 로직을 구현했습니다.

### 📸 스크린샷 (선택)
<img width="553" alt="image" src="https://github.com/user-attachments/assets/6fedec44-9b7a-4bbd-95af-9db26af33394" />


## 💬 리뷰 요구사항(선택)

> 유저 인가 인증 부분은 관련 코드 머지되면 한번에 수정하겠습니다 !
