### PR TITLE
🐛 [HOTFIX] #34 라벨 색상 타입 int로 변경

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -35,7 +35,7 @@ public enum ErrorStatus {
     // 라벨 관련 에러
     LABELS_NOT_FOUND(HttpStatus.BAD_REQUEST, "LABEL4001", "라벨을 찾을 수 없습니다."),
     LABEL_NAME_TOO_LONG(HttpStatus.BAD_REQUEST, "LABEL4002", "라벨 이름은 최대 20자까지 가능합니다."),
-    INVALID_COLOR(HttpStatus.BAD_REQUEST, "LABEL4003", "유효하지 않은 라벨 색상입니다.");
+    INVALID_COLOR(HttpStatus.BAD_REQUEST, "LABEL4003", "유효하지 않은 라벨 색상값입니다.");
 
 
     private final HttpStatus httpStatus;

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
@@ -19,6 +19,7 @@ public class LabelRequestDTO {
         private String name;
 
         @NotBlank(message = "(DTO)라벨 색상은 필수입니다.")
+        @Pattern(regexp = "^[0-9]{1,10}$", message = "컬러는 1자리 이상 10자리 이하의 숫자로만 이루어져야 합니다.")
         private String color;
     }
 

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
@@ -15,9 +15,9 @@ public class LabelRequestDTO {
         @NotBlank(message = "(DTO)라벨 이름은 필수입니다.")
         private String name;
 
-        @NotBlank(message = "(DTO)라벨 색상은 필수입니다.")
-        @Pattern(regexp = "^[0-9]{1,10}$", message = "컬러는 1자리 이상 10자리 이하의 숫자로만 이루어져야 합니다.")
-        private String color;
+        @Min(value = 0, message = "컬러는 0 이상의 숫자여야 합니다.")
+        @Max(value = 999999999, message = "컬러는 최대 10자리 이하의 숫자여야 합니다.")
+        private int color;
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -14,7 +14,7 @@ public class LabelResponseDTO {
     public static class CreateResultDto {
         private Long labelId;
         private String name;
-        private String color;
+        private int color;
     }
 
     @Getter
@@ -24,7 +24,7 @@ public class LabelResponseDTO {
     public static class ListResultDto {
         private Long labelId;
         private String name;
-        private String color;
+        private int color;
         private Long bubbleCount;
     }
 
@@ -35,7 +35,7 @@ public class LabelResponseDTO {
     public static class DetailResultDto {
         private Long labelId;
         private String name;
-        private String color;
+        private int color;
         private Long bubbleCount;
         private List<BubbleResponseDto.ListResultDto> bubbles;
     }

--- a/project/src/main/java/com/edison/project/domain/label/entity/Label.java
+++ b/project/src/main/java/com/edison/project/domain/label/entity/Label.java
@@ -18,49 +18,14 @@ public class Label extends BaseEntity {
     @Column(name = "label_id")
     private Long labelId;
 
-    @Column(name = "name", nullable = false, length = 100)
+    @Column(name = "name")
     private String name;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "color", nullable = false)
-    private LabelColor color;
+    @Column(name = "color", nullable = false, length = 10)
+    private String color;
 
     @ManyToOne
     @JoinColumn(name = "member_id") // 로그인 안한 유저 id값 없다면, nullable=true 추가
     private Member member;
-
-    public enum LabelColor {
-        PINK400("#FF47AD"),
-        PINK300("#FF6CBF"),
-        PINK100("#FBC1E5"),
-        RED500("#F44336"),
-        RED300("#E57373"),
-        RED100("#FBCDD2"),
-        YELLOW500("#FBC000"),
-        YELLOW300("#FFDC3A"),
-        YELLOW100("#FFF0AB"),
-        GREEN500("#00CC74"),
-        GREEN300("#5BDE9F"),
-        GREEN100("#BFF0D5"),
-        AQUA500("#00A2EE"),
-        AQUA300("#4CBEF3"),
-        AQUA100("#B2E3FA"),
-        INDIGO400("#5C6CC0"),
-        INDIGO300("#798BCB"),
-        INDIGO100("#C5CAE9"),
-        PURPLE500("#9632AF"),
-        PURPLE300("#B56CC8"),
-        PURPLE100("#DFBFE7");
-
-        private final String hexCode;
-
-        LabelColor(String hexCode) {
-            this.hexCode = hexCode;
-        }
-
-        public String getHexCode() {
-            return hexCode;
-        }
-    }
 
 }

--- a/project/src/main/java/com/edison/project/domain/label/entity/Label.java
+++ b/project/src/main/java/com/edison/project/domain/label/entity/Label.java
@@ -21,8 +21,8 @@ public class Label extends BaseEntity {
     @Column(name = "name")
     private String name;
 
-    @Column(name = "color", nullable = false, length = 10)
-    private String color;
+    @Column(name = "color", nullable = false)
+    private int color;
 
     @ManyToOne
     @JoinColumn(name = "member_id") // 로그인 안한 유저 id값 없다면, nullable=true 추가

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
@@ -39,7 +39,7 @@ public class LabelCommandServiceImpl implements LabelCommandService {
 
         Label label = Label.builder()
                 .name(request.getName())
-                .color(request.getColor()) // 라벨 String -> enum 명시적 변환
+                .color(request.getColor())
                 .member(member)
                 .build();
 

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelCommandServiceImpl.java
@@ -31,16 +31,9 @@ public class LabelCommandServiceImpl implements LabelCommandService {
             throw new GeneralException(ErrorStatus.LABEL_NAME_TOO_LONG);
         }
 
-        // 라벨 색상 Enum 값 검증
-        try {
-            Label.LabelColor.valueOf(request.getColor());
-        } catch (IllegalArgumentException e) {
-            throw new GeneralException(ErrorStatus.INVALID_COLOR);
-        }
-
         Label label = Label.builder()
                 .name(request.getName())
-                .color(Label.LabelColor.valueOf(request.getColor())) // 라벨 String -> enum 명시적 변환
+                .color(request.getColor()) // 라벨 String -> enum 명시적 변환
                 .member(member)
                 .build();
 
@@ -49,7 +42,7 @@ public class LabelCommandServiceImpl implements LabelCommandService {
         return LabelResponseDTO.CreateResultDto.builder()
                 .labelId(savedLabel.getLabelId())
                 .name(savedLabel.getName())
-                .color(savedLabel.getColor().name())
+                .color(savedLabel.getColor())
                 .build();
     }
 
@@ -64,16 +57,9 @@ public class LabelCommandServiceImpl implements LabelCommandService {
             throw new GeneralException(ErrorStatus.LABEL_NAME_TOO_LONG);
         }
 
-        // **중복: 라벨 색상 Enum 값 검증
-        try {
-            Label.LabelColor.valueOf(request.getColor());
-        } catch (IllegalArgumentException e) {
-            throw new GeneralException(ErrorStatus.INVALID_COLOR);
-        }
-
         Label updatedLabel = label.toBuilder()
                 .name(request.getName())
-                .color(Label.LabelColor.valueOf(request.getColor()))
+                .color(request.getColor())
                 .build();
 
         labelRepository.save(updatedLabel);
@@ -82,7 +68,7 @@ public class LabelCommandServiceImpl implements LabelCommandService {
         return LabelResponseDTO.CreateResultDto.builder()
                 .labelId(updatedLabel.getLabelId())
                 .name(updatedLabel.getName())
-                .color(updatedLabel.getColor().name())
+                .color(updatedLabel.getColor())
                 .build();
     }
 

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -38,7 +38,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
                     return LabelResponseDTO.ListResultDto.builder()
                             .labelId(label.getLabelId())
                             .name(label.getName())
-                            .color(label.getColor().name())
+                            .color(label.getColor())
                             .bubbleCount(bubbleCount != null ? bubbleCount : 0L) // 버블 없는 라벨은 0으로 처리
                             .build();
                 })
@@ -84,7 +84,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
         return LabelResponseDTO.DetailResultDto.builder()
                 .labelId(label.getLabelId())
                 .name(label.getName())
-                .color(label.getColor().name())
+                .color(label.getColor())
                 .bubbleCount((long) bubbleDetails.size())
                 .bubbles(bubbleDetails)
                 .build();


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #34 

## 📝 작업 내용

> 라벨 색상 타입 enum string에서, int로 변경하였습니다(0이상, 10자리 이하의 정수값으로 들어오도록)
> 들어오는 값 type검증은 일단 안했습니다!(다른 api들도 다 안된 것 같아서, 상위 exception 패키지에서 처리하는 게 나을 것 같아요)
<img width="519" alt="image" src="https://github.com/user-attachments/assets/3fa5df52-5d4d-4973-91b1-c0f1c93f7d1d" />
<img width="565" alt="image" src="https://github.com/user-attachments/assets/bec0ee0f-07f5-427a-b458-10236d8e7ac0" />

## 📝 리뷰 요구사항(선택)
>라벨 색상 int 아닌 타입으로 했을 시, 500에러 뜨는 거 확인해주세요! 
>(라벨 생성, POST) /labels