### PR TITLE
✨[FEAT] #11: 버블 수정 기능 구현 및 버블 출력 dto 형식 수정

### DIFF
--- a/project/src/main/java/com/edison/project/ProjectApplication.java
+++ b/project/src/main/java/com/edison/project/ProjectApplication.java
@@ -3,7 +3,9 @@ package com.edison.project;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 @EntityScan(basePackages = "com.edison.project.domain")
 public class ProjectApplication {

--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -78,6 +78,7 @@ public class BubbleRestController {
 
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return bubbleService.getDeletedBubbles(userPrincipal, pageable);
+    }
 
     // 버블 상세정보 조회
     @GetMapping("/{bubbleId}")
@@ -119,4 +120,18 @@ public class BubbleRestController {
         Pageable pageable = PageRequest.of(page, size);
         return bubbleService.searchBubbles(userPrincipal, keyword, recent, pageable);
     }
+
+    // 버블 수정
+    @PatchMapping("/{bubbleId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> updateBubble(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @PathVariable Long bubbleId,
+            @RequestBody @Valid BubbleRequestDto.ListDto request
+    ) {
+        BubbleResponseDto.ListResultDto response = bubbleService.updateBubble(userPrincipal, bubbleId, request);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -51,7 +51,7 @@ public class BubbleResponseDto {
         private String title;
         private String content;
         private String mainImageUrl;
-        private List<String> labels;
+        private List<LabelResponseDTO.CreateResultDto> labels;
         private Long linkedBubbleId;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -1,5 +1,6 @@
 package com.edison.project.domain.bubble.dto;
 
+import com.edison.project.domain.label.dto.LabelResponseDTO;
 import lombok.*;
 
 import java.time.LocalDateTime;
@@ -17,7 +18,7 @@ public class BubbleResponseDto {
         private String title;
         private String content;
         private String mainImageUrl;
-        private List<String> labels;
+        private List<LabelResponseDTO.CreateResultDto> labels;
         private Long linkedBubbleId;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -55,6 +55,17 @@ public class Bubble extends BaseEntity {
         this.labels = labels;
     }
 
+    public void update(String title, String content, String mainImg, Bubble linkedBubble, Set<BubbleLabel> bubbleLabels) {
+        this.title = title;
+        this.content = content;
+        this.mainImg = mainImg;
+        this.linkedBubble = linkedBubble;
+
+        // 기존 라벨 초기화 후 새로운 라벨 추가
+        this.labels.clear();
+        this.labels.addAll(bubbleLabels);
+    }
+
     public void setLabels(Set<BubbleLabel> labels) {
         this.labels = labels;
     }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
@@ -17,8 +17,10 @@ public interface BubbleService {
 
     BubbleResponseDto.RestoreResultDto restoreBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
 
-    ResponseEntity<ApiResponse> getBubblesByMember(Long memberId, Pageable pageable);
+    BubbleResponseDto.ListResultDto updateBubble(CustomUserPrincipal userPrincipal, Long bubbleId, BubbleRequestDto.ListDto requestDto);
+
     ResponseEntity<ApiResponse> getDeletedBubbles(CustomUserPrincipal userPrincipal, Pageable pageable);
+
     BubbleResponseDto.ListResultDto getBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
 
     ResponseEntity<ApiResponse> getBubblesByMember(CustomUserPrincipal userPrincipal, Pageable pageable);

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -16,6 +16,8 @@ import com.edison.project.domain.label.repository.LabelRepository;
 import com.edison.project.domain.member.entity.Member;
 import com.edison.project.domain.member.repository.MemberRepository;
 import com.edison.project.global.security.CustomUserPrincipal;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -41,6 +43,9 @@ public class BubbleServiceImpl implements BubbleService {
     private final BubbleLabelRepository bubbleLabelRepository;
     private final LabelRepository labelRepository;
     private final MemberRepository memberRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     @Override
     @Transactional
@@ -186,6 +191,8 @@ public class BubbleServiceImpl implements BubbleService {
         bubble.update(requestDto.getTitle(), requestDto.getContent(), requestDto.getMainImageUrl(), linkedBubble, bubbleLabels);
 
         bubbleRepository.save(bubble);
+
+        entityManager.flush();
 
         return BubbleResponseDto.ListResultDto.builder()
                 .bubbleId(bubble.getBubbleId())

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -248,27 +248,35 @@ public class BubbleServiceImpl implements BubbleService {
                 bubblePage.getTotalElements(), bubblePage.getTotalPages());
 
         // Bubble 데이터 변환
+        // Bubble -> DeletedListResultDto 변환
         List<BubbleResponseDto.DeletedListResultDto> bubbles = bubblePage.getContent().stream()
                 .map(bubble -> {
-                            LocalDateTime updatedAt = bubble.getUpdatedAt();
-                            LocalDateTime now = LocalDateTime.now();
-                            long remainDays = 30 - ChronoUnit.DAYS.between(updatedAt, now);
+                    LocalDateTime updatedAt = bubble.getUpdatedAt();
+                    LocalDateTime now = LocalDateTime.now();
+                    long remainDays = 30 - ChronoUnit.DAYS.between(updatedAt, now);
 
-                            return BubbleResponseDto.DeletedListResultDto.builder()
-                                    .bubbleId(bubble.getBubbleId())
-                                    .title(bubble.getTitle())
-                                    .content(bubble.getContent())
-                                    .mainImageUrl(bubble.getMainImg())
-                                    .labels(bubble.getLabels().stream()
-                                            .map(label -> label.getLabel().getName())
-                                            .collect(Collectors.toList()))
-                                    .linkedBubbleId(Optional.ofNullable(bubble.getLinkedBubble())
-                                            .map(Bubble::getBubbleId)
-                                            .orElse(null))
-                                    .createdAt(bubble.getCreatedAt())
-                                    .updatedAt(updatedAt)
-                                    .remainDay((int) Math.max(remainDays, 0))
-                                    .build();
+                    // 라벨 정보 변환
+                    List<LabelResponseDTO.CreateResultDto> labelDtos = bubble.getLabels().stream()
+                            .map(bl -> LabelResponseDTO.CreateResultDto.builder()
+                                    .labelId(bl.getLabel().getLabelId())
+                                    .name(bl.getLabel().getName())
+                                    .color(bl.getLabel().getColor())
+                                    .build())
+                            .collect(Collectors.toList());
+
+                    return BubbleResponseDto.DeletedListResultDto.builder()
+                            .bubbleId(bubble.getBubbleId())
+                            .title(bubble.getTitle())
+                            .content(bubble.getContent())
+                            .mainImageUrl(bubble.getMainImg())
+                            .labels(labelDtos) // 라벨 정보 추가
+                            .linkedBubbleId(Optional.ofNullable(bubble.getLinkedBubble())
+                                    .map(Bubble::getBubbleId)
+                                    .orElse(null))
+                            .createdAt(bubble.getCreatedAt())
+                            .updatedAt(updatedAt)
+                            .remainDay((int) Math.max(remainDays, 0)) // 남은 일수 계산
+                            .build();
                 })
                 .collect(Collectors.toList());
 

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -73,30 +73,40 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
         List<Bubble> bubbles = bubbleLabelRepository.findBubblesByLabelId(labelId);
 
-        // BubbleDetailDto 변환
-        //** map 내부의 함수 -> 버블 상세내용조회 api 구현 후 함수로 뽑아 중복 제거 가능
         List<BubbleResponseDto.ListResultDto> bubbleDetails = bubbles.stream()
-                .map(bubble -> BubbleResponseDto.ListResultDto.builder()
-                        .bubbleId(bubble.getBubbleId())
-                        .title(bubble.getTitle())
-                        .content(bubble.getContent())
-                        .mainImageUrl(bubble.getMainImg())
-                        .labels(bubble.getLabels().stream()
-                                .map(bl -> bl.getLabel().getName())
-                                .collect(Collectors.toList()))
-                        .linkedBubbleId(bubble.getLinkedBubble() != null ? bubble.getLinkedBubble().getBubbleId() : null)
-                        .createdAt(bubble.getCreatedAt())
-                        .updatedAt(bubble.getUpdatedAt())
-                        .build())
+                .map(this::convertToBubbleResponseDto)
                 .collect(Collectors.toList());
 
-        // DetailResultDto 반환
+        // BubbleDetailDto 변환
         return LabelResponseDTO.DetailResultDto.builder()
                 .labelId(label.getLabelId())
                 .name(label.getName())
                 .color(label.getColor())
                 .bubbleCount((long) bubbleDetails.size())
                 .bubbles(bubbleDetails)
+                .build();
+
+        }
+
+    // Bubble -> BubbleResponseDto 변환 함수 (중복 제거)
+    private BubbleResponseDto.ListResultDto convertToBubbleResponseDto(Bubble bubble) {
+        List<LabelResponseDTO.CreateResultDto> labelDtos = bubble.getLabels().stream()
+                .map(bl -> LabelResponseDTO.CreateResultDto.builder()
+                        .labelId(bl.getLabel().getLabelId())
+                        .name(bl.getLabel().getName())
+                        .color(bl.getLabel().getColor())
+                        .build())
+                .collect(Collectors.toList());
+
+        return BubbleResponseDto.ListResultDto.builder()
+                .bubbleId(bubble.getBubbleId())
+                .title(bubble.getTitle())
+                .content(bubble.getContent())
+                .mainImageUrl(bubble.getMainImg())
+                .labels(labelDtos) // 라벨 정보 리스트
+                .linkedBubbleId(bubble.getLinkedBubble() != null ? bubble.getLinkedBubble().getBubbleId() : null)
+                .createdAt(bubble.getCreatedAt())
+                .updatedAt(bubble.getUpdatedAt())
                 .build();
     }
 

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=project
 
 # MySQL Database Connection
-spring.datasource.url=jdbc:mysql://localhost:3306/edison_db?useSSL=false&serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://localhost:3306/edison?useSSL=false&serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=${DB_password}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #24 

## 📝 작업 내용

- [x] 버블 수정 기능 구현
- updatedAt 시간 동기화가 잘 안되어서 EntityManager flush 하고 출력하는 방식으로 구현했습니다.
<img width="961" alt="image" src="https://github.com/user-attachments/assets/cd101853-6b71-4148-afe9-d8fab6d0ebae" />


- [x] 버블 response 공통 형식 로직 생성
- 버블 클래스에서 겹치는 코드가 너무 많아서 `convertToBubbleResponseDto(Bubble bubble)` 공통함수 생성하였습니다.
<img width="877" alt="image" src="https://github.com/user-attachments/assets/1fdef7af-927d-4bc8-91ce-3482a9588e90" />


- [x] 관련 로직 모두 수정 (버블 생성, 조회, 삭제, 복원, 검색 관련) + API 명세서 수정해두었습니다.


### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 관련 로직 중 제가 수정하지 못한 api가 있다면 알려주십셔 !
