### PR TITLE
✨[FEAT] #64: 아트레터 페이지 상세정보 조회 구현

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -46,8 +46,7 @@ public enum ErrorStatus {
     CONTENT_VALIDATION(HttpStatus.BAD_REQUEST, "LETTER4006", "content field 관련 오류"),
     TAG_VALIDATION(HttpStatus.BAD_REQUEST, "LETTER4007", "tag field 관련 오류"),
     CATEGORY_VALIDATION(HttpStatus.BAD_REQUEST, "LETTER4008", "category field 관련 오류"),
-    KEYWORD_IS_EMPTY(HttpStatus.BAD_REQUEST, "LETTER4009", "keyword field 관련 오류");
-    INVALID_COLOR(HttpStatus.BAD_REQUEST, "LABEL4003", "유효하지 않은 라벨 색상값입니다."),
+    KEYWORD_IS_EMPTY(HttpStatus.BAD_REQUEST, "LETTER4009", "keyword field 관련 오류"),
 
     // 검색 관련 에러
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH4001", "검색어는 공백일 수 없습니다.");

--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -47,6 +47,7 @@ public enum ErrorStatus {
     TAG_VALIDATION(HttpStatus.BAD_REQUEST, "LETTER4007", "tag field 관련 오류"),
     CATEGORY_VALIDATION(HttpStatus.BAD_REQUEST, "LETTER4008", "category field 관련 오류"),
     KEYWORD_IS_EMPTY(HttpStatus.BAD_REQUEST, "LETTER4009", "keyword field 관련 오류"),
+    LETTERS_NOT_FOUND(HttpStatus.BAD_REQUEST, "LABEL4010", "아트레터를 찾을 수 없습니다."),
 
     // 검색 관련 에러
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH4001", "검색어는 공백일 수 없습니다.");

--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -6,12 +6,16 @@ import com.edison.project.common.status.ErrorStatus;
 import com.edison.project.common.status.SuccessStatus;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.artletter.repository.ArtletterRepository;
 import com.edison.project.domain.artletter.service.ArtletterService;
+import com.edison.project.global.security.CustomUserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.LinkedHashMap;
@@ -25,6 +29,7 @@ import java.util.stream.Collectors;
 public class ArtletterController {
 
     private final ArtletterService artletterService;
+    private final ArtletterRepository artletterRepository;
 
     // POST: 아트레터 등록
     @PostMapping
@@ -151,5 +156,14 @@ public class ArtletterController {
         Page<Artletter> results = artletterService.searchArtletters(keyword, pageable);
 
         return ApiResponse.onSuccess(SuccessStatus._OK, results.getContent());
+    }
+
+    @GetMapping("/{letterId}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> getArtletterInfo(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @PathVariable("letterId") Long letterId) {
+        ArtletterDTO.ListResponseDto response = artletterService.getArtletter(userPrincipal, letterId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
@@ -8,6 +8,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import com.edison.project.domain.artletter.entity.Artletter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -53,9 +54,18 @@ public class ArtletterDTO {
     public static class ListResponseDto {
         private Long artletterId;
         private String title;
+        private String content;
+        private String category;
+        private int readTime;
+        private String writer;
+        private String tags;
         private String thumbnail;
-        private int likes;
-        private int scraps;
+        private int likesCnt;
+        private int scrapsCnt;
+        private boolean isLiked;
+        private boolean isScraped;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/entity/Artletter.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/entity/Artletter.java
@@ -41,7 +41,7 @@ public class Artletter extends BaseEntity {
     private ArtletterCategory category;
 
     public enum ArtletterCategory {
-        CATEGORY1, CATEGORY2, CATEGORY3
+        기술, 현대미술, 영화예술
     }
 
     private String thumbnail;

--- a/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterLikesRepository.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterLikesRepository.java
@@ -1,5 +1,6 @@
 package com.edison.project.domain.artletter.repository;
 
+import com.edison.project.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import com.edison.project.domain.artletter.entity.ArtletterLikes;
@@ -8,4 +9,5 @@ import com.edison.project.domain.artletter.entity.Artletter;
 @Repository
 public interface ArtletterLikesRepository extends JpaRepository<ArtletterLikes, Long> {
     int countByArtletter(Artletter artletter);
+    boolean existsByMemberAndArtletter(Member member, Artletter artletter);
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -3,6 +3,7 @@ package com.edison.project.domain.artletter.service;
 import com.edison.project.common.response.ApiResponse;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.global.security.CustomUserPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -15,4 +16,6 @@ public interface ArtletterService {
     ArtletterDTO.CreateResponseDto createArtletter(ArtletterDTO.CreateRequestDto request);
 
     Page<Artletter> searchArtletters(String keyword, Pageable pageable);
+
+    ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId);
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -1,9 +1,18 @@
 package com.edison.project.domain.artletter.service;
 
+import com.edison.project.common.exception.GeneralException;
 import com.edison.project.common.response.PageInfo;
+import com.edison.project.common.status.ErrorStatus;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.artletter.repository.ArtletterLikesRepository;
 import com.edison.project.domain.artletter.repository.ArtletterRepository;
+import com.edison.project.domain.member.entity.Member;
+import com.edison.project.domain.member.repository.MemberRepository;
+import com.edison.project.domain.scrap.repository.ScrapRepository;
+import com.edison.project.global.security.CustomUserPrincipal;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -14,14 +23,15 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+
 @Service
+@RequiredArgsConstructor
 public class ArtletterServiceImpl implements ArtletterService {
 
     private final ArtletterRepository artletterRepository;
-
-    public ArtletterServiceImpl(ArtletterRepository artletterRepository) {
-        this.artletterRepository = artletterRepository;
-    }
+    private final ArtletterLikesRepository artletterLikesRepository;
+    private final ScrapRepository scrapRepository;
+    private final MemberRepository memberRepository;
 
     public Page<Artletter> getAllArtletters(int page, int size) {
         // 페이지 요청 생성
@@ -53,5 +63,40 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     public Page<Artletter> searchArtletters(String keyword, Pageable pageable) {
         return artletterRepository.searchByKeyword(keyword, pageable);
+    }
+
+    @Override
+    public ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId) {
+        if (userPrincipal == null) {
+            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
+        }
+
+        Artletter artletter = artletterRepository.findById(letterId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.LETTERS_NOT_FOUND));
+
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        boolean isLiked = artletterLikesRepository.existsByMemberAndArtletter(member, artletter);
+        int likesCnt = artletterLikesRepository.countByArtletter(artletter);
+        boolean isScrapped = scrapRepository.existsByMemberAndArtletter(member, artletter);
+        int scrapCnt = scrapRepository.countByArtletter(artletter);
+
+        return ArtletterDTO.ListResponseDto.builder()
+                .artletterId(artletter.getLetterId())
+                .title(artletter.getTitle())
+                .content(artletter.getContent())
+                .tags(artletter.getTag())
+                .writer(artletter.getWriter())
+                .category(String.valueOf(artletter.getCategory()))
+                .readTime(artletter.getReadTime())
+                .thumbnail(artletter.getThumbnail())
+                .likesCnt(likesCnt)
+                .scrapsCnt(scrapCnt)
+                .isLiked(isLiked)
+                .isScraped(isScrapped)
+                .createdAt(artletter.getCreatedAt())
+                .updatedAt(artletter.getUpdatedAt())
+                .build();
     }
 }

--- a/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
+++ b/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
@@ -1,0 +1,11 @@
+package com.edison.project.domain.scrap.repository;
+
+import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.member.entity.Member;
+import com.edison.project.domain.scrap.entity.Scrap;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScrapRepository extends JpaRepository<Scrap, Long> {
+    int countByArtletter(Artletter artletter);
+    boolean existsByMemberAndArtletter(Member member, Artletter artletter);
+}

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -1,7 +1,7 @@
 spring.application.name=project
 
 # MySQL Database Connection
-spring.datasource.url=jdbc:mysql://localhost:3306/edison?useSSL=false&serverTimezone=Asia/Seoul
+spring.datasource.url=jdbc:mysql://localhost:3306/edison_db?useSSL=false&serverTimezone=Asia/Seoul
 spring.datasource.username=root
 spring.datasource.password=${DB_password}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver


### PR DESCRIPTION

## #⃣ 연관된 이슈

close #64 

## 📝 작업 내용

> 아트레터 페이지에 필요한 상세정보를 조회하는 api를 구현하였습니다.

### 📸 스크린샷 (선택)
<img width="581" alt="image" src="https://github.com/user-attachments/assets/d35ad673-19a8-4f74-b0c6-04db1ed1d39c" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
