### PR TITLE
🐛 [!HOTFIX] #83 refresh토큰으로 access토큰 재발급

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -35,6 +35,8 @@ public enum ErrorStatus {
     IDENTITY_ALREADY_SET(HttpStatus.BAD_REQUEST, "MEMBER4003", "아이덴티티 키워드는 최초 1회만 설정 가능합니다."),
     INVALID_CATEGORY(HttpStatus.BAD_REQUEST, "MEMBER4004", "존재하지 않는 카테고리입니다."),
     INVALID_IDENTITY_MAPPING(HttpStatus.BAD_REQUEST, "MEMBER4005", "카테고리와 키워드가 일치하지 않습니다."),
+    NICKNAME_ALREADY_SET(HttpStatus.BAD_REQUEST, "MEMBER4006", "닉네임은 최초 1회만 설정 가능합니다."),
+    NICKNAME_TOO_LONG(HttpStatus.BAD_REQUEST, "MEMBER4007", "20자이내의 닉네임을 설정해주세요."),
 
     // 버블 관련 애러
     BUBBLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BUBBLE4001", "버블을 찾을 수 없습니다."),

--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -38,8 +38,8 @@ public class MemberRestController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse> refreshAccessToken(@RequestAttribute("expiredAccessToken") String token) {
-        return memberService.refreshAccessToken(token);
+    public ResponseEntity<ApiResponse> refreshAccessToken(@RequestAttribute("refreshToken") String refreshToken) {
+        return memberService.refreshAccessToken(refreshToken);
     }
 
     @PostMapping("/identity")

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
@@ -18,6 +18,7 @@ public class MemberRequestDto {
     public static class ProfileDto {
 
         @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
         private String nickname;
     }
 
@@ -28,6 +29,7 @@ public class MemberRequestDto {
     public static class UpdateProfileDto {
 
         @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
         private String nickname;
 
         private String imageUrl;

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -95,18 +95,24 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     @Transactional
-
     public ResponseEntity<ApiResponse> registerMember(CustomUserPrincipal userPrincipal,  MemberRequestDto.ProfileDto request) {
         if (userPrincipal == null) {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
-
         Member member = memberRepository.findById(userPrincipal.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
+        if(member.getNickname()!=null){
+            throw new GeneralException(ErrorStatus.NICKNAME_ALREADY_SET);
+        }
+
         if (request.getNickname()==null || request.getNickname() == "") {
             throw new GeneralException(ErrorStatus.NICKNAME_NOT_EXIST);
+        }
+
+        if (request.getNickname().length() > 20) {
+            throw new GeneralException(ErrorStatus.NICKNAME_TOO_LONG);
         }
 
         member = member.registerProfile(request.getNickname());

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -186,22 +186,12 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     @Transactional
-    public ResponseEntity<ApiResponse> refreshAccessToken(String token) {
+    public ResponseEntity<ApiResponse> refreshAccessToken(String refreshToken) {
 
-        Long memberId = jwtUtil.extractUserId(token);
-        String email = jwtUtil.extractEmail(token);
-
-        RefreshToken refreshToken = refreshTokenRepository.findByEmail(email)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_REQUIRED));
-
-        if (jwtUtil.isTokenExpired(refreshToken.getRefreshToken())) {
-            throw new GeneralException(ErrorStatus.REFRESHTOKEN_EXPIRED);
-        }
+        Long memberId = jwtUtil.extractUserId(refreshToken);
+        String email = jwtUtil.extractEmail(refreshToken);
 
         String newAccessToken = jwtUtil.generateAccessToken(memberId, email);
-
-        // 전에 발급받은 access token 블랙리스트에 추가
-        redisTokenService.addToBlacklist(token, jwtUtil.getRemainingTime(token));
 
         MemberResponseDto.RefreshResultDto response = MemberResponseDto.RefreshResultDto.builder()
                 .accessToken(newAccessToken)

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -89,24 +89,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private void handleRefreshRequest(HttpServletRequest request, String token) {
+        String refreshToken = request.getHeader("Refresh-Token");
+
+        if (refreshToken == null || refreshToken.isBlank()) {
+            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED); // Refresh Token이 없을 때 예외 처리
+        }
+
         String email = jwtUtil.extractEmail(token);
 
         // Refresh Token 검증
-        RefreshToken refreshToken = refreshTokenRepository.findByEmail(email)
+        RefreshToken storedRefreshToken = refreshTokenRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_REQUIRED));
 
-        if (jwtUtil.isTokenExpired(refreshToken.getRefreshToken())) {
-            // Refresh Token이 만료된 경우 Access Token 블랙리스트 처리
-            redisTokenService.addToBlacklist(token, jwtUtil.getRemainingTime(token));
+        if(!jwtUtil.isTokenExpired(token)){
+            throw new GeneralException(ErrorStatus.ACCESS_TOKEN_VALID);
+        }
+
+        if (jwtUtil.isTokenExpired(storedRefreshToken.getRefreshToken())) {
+            // Refresh Token이 만료된 경우 블랙리스트 처리
+            redisTokenService.addToBlacklist(String.valueOf(storedRefreshToken), jwtUtil.getRemainingTime(String.valueOf(storedRefreshToken)));
             throw new GeneralException(ErrorStatus.REFRESHTOKEN_EXPIRED);
         }
 
-        if (jwtUtil.isTokenExpired(token)) {
-            // Access Token이 만료되었어도 진행
-            request.setAttribute("expiredAccessToken", token);
+        if (!storedRefreshToken.getRefreshToken().equals(refreshToken)) {
+            throw new GeneralException(ErrorStatus.INVALID_TOKEN); // Refresh Token이 저장된 것과 다를 때 예외 처리
         }
-        else{
-            throw new GeneralException(ErrorStatus.ACCESS_TOKEN_VALID);
-        }
+
+        request.setAttribute("refreshToken", refreshToken);
+
     }
 }

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -106,8 +106,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         if (jwtUtil.isTokenExpired(storedRefreshToken.getRefreshToken())) {
-            // Refresh Token이 만료된 경우 블랙리스트 처리
-            redisTokenService.addToBlacklist(String.valueOf(storedRefreshToken), jwtUtil.getRemainingTime(String.valueOf(storedRefreshToken)));
             throw new GeneralException(ErrorStatus.REFRESHTOKEN_EXPIRED);
         }
 

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -1,0 +1,33 @@
+spring.application.name=project
+
+# MySQL Database Connection
+spring.datasource.url=${RDS_URL}
+spring.datasource.username=${RDS_USERNAME}
+spring.datasource.password=${RDS_PASSWORD}
+
+
+# Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# JPA Console Log
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+# Google OAuth2
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=openid,email
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.provider.google.issuer-uri=https://accounts.google.com
+
+# JWT
+jwt.secret=${JWT_SECRET}
+jwt.access-token-expiration=${JWT_ACCESS_EXPIRATION}
+jwt.refresh-token-expiration=${JWT_REFRESH_EXPIRATION}
+
+# redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #83 

## 📝 작업 내용

> access토큰 재발급 받을 때 헤더에 access토큰과 refresh토큰 둘다 요청하는 방법으로 바꿨습니다! 현재 배포된 서버에는 다른 application.properties가 적용되고 있어서 로컬서버에서 진행해야합니다! 만료된 토큰으로 재발급 테스트 할 때는 환경변수 JWT_ACCESS_EXPIRATION,  JWT_REFRESH_EXPIRATION이 값을 바꾸고 확인해주세요!

- 재발급 성공(access토큰 만료, refresh토큰 유효)
<img width="1014" alt="스크린샷 2025-01-24 오후 2 57 48" src="https://github.com/user-attachments/assets/1d0a97f6-8cc2-4d8a-9ea3-0eb223fd4f91" />

- access 토큰 유효할 때 재발급
<img width="695" alt="스크린샷 2025-01-24 오후 4 00 53" src="https://github.com/user-attachments/assets/05b94274-2300-44dc-9bff-7e1548dc7e61" />

- access토큰, refresh토큰 모두 만료
<img width="683" alt="스크린샷 2025-01-24 오후 4 02 37" src="https://github.com/user-attachments/assets/ef5deb1b-772f-434a-9059-38e82f936996" />

- 로그아웃하고 재발급 한 경우
<img width="687" alt="스크린샷 2025-01-24 오후 4 26 18" src="https://github.com/user-attachments/assets/a1478b58-0364-464e-bd62-6a8396b0cc4a" />


- access 토큰 만료되었을 때 다른 api 요청
<img width="1008" alt="스크린샷 2025-01-24 오후 2 56 20" src="https://github.com/user-attachments/assets/4a618c60-1f44-42e6-953d-1d2fd85509ac" />



### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

## pr할 때 application.properties 파일 삭제하고 머지하겠습니당
