### PR TITLE
✨ [FEAT] #57 계정 탈퇴 API 

### DIFF
--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -57,4 +57,11 @@ public class MemberRestController {
         MemberResponseDto.IdentityKeywordsResultDto result = memberService.getIdentityKeywords(userPrincipal);
         return ApiResponse.onSuccess(SuccessStatus._OK, result);
     }
+
+    @DeleteMapping("/cancel")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> cancel(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        return memberService.cancel(userPrincipal);
+    }
+
 }

--- a/project/src/main/java/com/edison/project/domain/member/repository/MemberRepository.java
+++ b/project/src/main/java/com/edison/project/domain/member/repository/MemberRepository.java
@@ -9,4 +9,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     // 추가 쿼리 메서드는 여기 작성
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
+    boolean existsByMemberId(Long memberId);
+    void deleteByMemberId(Long memeberId);
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
@@ -15,4 +15,5 @@ public interface MemberService {
     ResponseEntity<ApiResponse> refreshAccessToken(String token);
     MemberResponseDto.IdentityTestSaveResultDto saveIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
     MemberResponseDto.IdentityKeywordsResultDto getIdentityKeywords(CustomUserPrincipal userPrincipal);
+    ResponseEntity<ApiResponse> cancel(CustomUserPrincipal userPrincipal);
 }

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -98,6 +98,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private void handleRefreshRequest(HttpServletRequest request, String token) {
         String email = jwtUtil.extractEmail(token);
 
+        if(!memberRepository.existsByEmail(email)){
+            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
+        }
+
         // Refresh Token 검증
         RefreshToken refreshToken = refreshTokenRepository.findByEmail(email)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LOGIN_REQUIRED));

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -1,0 +1,33 @@
+spring.application.name=project
+
+# MySQL Database Connection
+spring.datasource.url=${RDS_URL}
+spring.datasource.username=${RDS_USERNAME}
+spring.datasource.password=${RDS_PASSWORD}
+
+
+# Hibernate Configuration
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.show-sql=true
+spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
+
+# JPA Console Log
+logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.hibernate.type.descriptor.sql=TRACE
+
+# Google OAuth2
+spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID}
+spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET}
+spring.security.oauth2.client.registration.google.scope=openid,email
+spring.security.oauth2.client.registration.google.redirect-uri=http://localhost:8080/login/oauth2/code/google
+spring.security.oauth2.client.provider.google.issuer-uri=https://accounts.google.com
+
+# JWT
+jwt.secret=${JWT_SECRET}
+jwt.access-token-expiration=${JWT_ACCESS_EXPIRATION}
+jwt.refresh-token-expiration=${JWT_REFRESH_EXPIRATION}
+
+# redis
+spring.data.redis.host=localhost
+spring.data.redis.port=6379


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #57 

## 📝 작업 내용

> 회원 탈퇴하는 API입니다.

## 로컬서버로 진행해주세용 db는 rds입니다! 머지할 때 application.properties파일 지우고 머지하도록 하겠습니다.

### 📸 스크린샷 (선택)
- 탈퇴 성공
<img width="695" alt="스크린샷 2025-01-24 오후 5 20 51" src="https://github.com/user-attachments/assets/28dff2c7-fe82-4b4e-8aac-8236984071b0" />

- 탈퇴 후 다른 api 요청
<img width="682" alt="스크린샷 2025-01-24 오후 5 43 43" src="https://github.com/user-attachments/assets/1921ceee-80ed-4313-9d44-45c67590a911" />

