### PR TITLE
✨[FEAT] #98: 버블 SYNC 기능 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml

--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -148,5 +148,15 @@ public class BubbleRestController {
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
+    // 버블 SYNC
+    @PostMapping("/sync")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> syncBubble(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @RequestBody @Valid BubbleRequestDto.SyncDto request) {
+        BubbleResponseDto.SyncResultDto response = bubbleService.syncBubble(userPrincipal, request);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
 }
 

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -1,10 +1,12 @@
 package com.edison.project.domain.bubble.dto;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Set;
 
@@ -37,5 +39,26 @@ public class BubbleRequestDto {
     @AllArgsConstructor
     public static class RestoreDto {
         private Long bubbleId;
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SyncDto {
+        @NotNull(message = "(DTO)버블 ID는 필수입니다.")
+        private Long BubbleId;
+
+        private String title;
+        private String content;
+        private String mainImageUrl;
+        private Set<Long> labelIds;
+        private Long linkedBubbleId;
+
+        @NotNull(message = "(DTO)삭제 여부는 필수입니다.")
+        private boolean isDeleted;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private LocalDateTime deletedAt;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -1,5 +1,6 @@
 package com.edison.project.domain.bubble.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -56,9 +57,14 @@ public class BubbleRequestDto {
         private Long linkedBubbleId;
 
         @NotNull(message = "(DTO)삭제 여부는 필수입니다.")
+        @JsonProperty("isDeleted")
         private boolean isDeleted;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;
+
+        public boolean isDeleted() {
+            return isDeleted;
+        }
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -57,4 +57,21 @@ public class BubbleResponseDto {
         private LocalDateTime updatedAt;
         private Integer remainDay;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class SyncResultDto {
+        private Long bubbleId;
+        private String title;
+        private String content;
+        private String mainImageUrl;
+        private List<LabelResponseDTO.CreateResultDto> labels;
+        private Long linkedBubbleId;
+        private Boolean isDeleted;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private LocalDateTime deletedAt;
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -5,12 +5,14 @@ import com.edison.project.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.HashSet;
 import java.util.Set;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
+@Setter
 @Table(name = "Bubble", indexes = {
         @Index(name = "idx_bubble_member_id", columnList = "member_id"),
         @Index(name = "idx_bubble_title", columnList = "title")})
@@ -18,7 +20,7 @@ import java.util.Set;
 public class Bubble extends BaseEntity {
 
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    // @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bubble_id")
     private Long bubbleId;
 
@@ -46,13 +48,21 @@ public class Bubble extends BaseEntity {
     private Set<BubbleLabel> labels = new HashSet<>();
 
     @Builder
-    public Bubble(Member member, String title, String content, String mainImg, Bubble linkedBubble, Set<BubbleLabel> labels) {
+    public Bubble(Member member, Long bubbleId, String title, String content, String mainImg, Bubble linkedBubble, Set<BubbleLabel> labels,
+                  boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+        this.bubbleId = bubbleId;
         this.member = member;
         this.title = title;
         this.content = content;
         this.mainImg = mainImg;
         this.linkedBubble = linkedBubble;
-        this.labels = labels;
+        // 기존 라벨 초기화 후 새로운 라벨 추가
+        this.labels.clear();
+        this.labels.addAll(labels);
+        this.isDeleted = isDeleted;
+        this.setCreatedAt(createdAt);
+        this.setUpdatedAt(updatedAt);
+        this.setDeletedAt(deletedAt);
     }
 
     public void update(String title, String content, String mainImg, Bubble linkedBubble, Set<BubbleLabel> bubbleLabels) {

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -1,6 +1,5 @@
 package com.edison.project.domain.bubble.entity;
 
-import com.edison.project.global.common.entity.BaseEntity;
 import com.edison.project.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,7 +16,7 @@ import java.util.Set;
         @Index(name = "idx_bubble_member_id", columnList = "member_id"),
         @Index(name = "idx_bubble_title", columnList = "title")})
 
-public class Bubble extends BaseEntity {
+public class Bubble {
 
     @Id
     // @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,6 +38,16 @@ public class Bubble extends BaseEntity {
 
     @Column(name = "is_deleted", nullable = false)
     private boolean isDeleted = false;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    protected LocalDateTime createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    protected LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at", nullable = true)
+    protected LocalDateTime deletedAt;
+
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "linked_bubble")
@@ -82,6 +91,10 @@ public class Bubble extends BaseEntity {
 
     public void setDeleted(boolean deleted) {
         this.isDeleted = deleted;
+    }
+
+    public boolean isDeleted() {
+        return isDeleted;
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
@@ -32,4 +32,6 @@ public interface BubbleService {
     ResponseEntity<ApiResponse> hardDelteBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
 
     void deleteExpiredBubble();
+
+    BubbleResponseDto.SyncResultDto syncBubble(CustomUserPrincipal userPrincipal, BubbleRequestDto.SyncDto requestDto);
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -523,7 +523,10 @@ public class BubbleServiceImpl implements BubbleService {
         bubble.setUpdatedAt(request.getUpdatedAt());
         bubble.setDeletedAt(request.getDeletedAt());
 
-        bubbleRepository.save(bubble);
+        System.out.println("Request isDeleted: " + request.isDeleted());
+        System.out.println("Before Update Bubble isDeleted: " + bubble.isDeleted());
+
+        bubbleRepository.saveAndFlush(bubble);
         return bubble;
     }
 

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -552,6 +552,6 @@ public class BubbleServiceImpl implements BubbleService {
 
         savedBubble.getLabels().addAll(bubbleLabels);
 
-        return newBubble;
+        return savedBubble;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -25,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import org.springframework.data.domain.Pageable;
@@ -436,6 +437,64 @@ public class BubbleServiceImpl implements BubbleService {
 
     }
 
+    @Override
+    @Transactional
+    public BubbleResponseDto.SyncResultDto syncBubble(CustomUserPrincipal userPrincipal, BubbleRequestDto.SyncDto request) {
+        if (userPrincipal == null) {
+            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
+        }
+
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // linkedBubble 검증
+        Bubble linkedBubble = null;
+        if (request.getLinkedBubbleId() != null) {
+            linkedBubble = bubbleRepository.findById(request.getLinkedBubbleId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
+        }
+
+        // 라벨 검증
+        Set<Long> labelIds = Optional.ofNullable(request.getLabelIds()).orElse(Collections.emptySet());
+        if (labelIds.size() > 3) throw new GeneralException(ErrorStatus.LABELS_TOO_MANY);
+
+        Set<Label> labels = new HashSet<>(labelRepository.findAllById(labelIds));
+        if (labels.size() != labelIds.size()) throw new GeneralException(ErrorStatus.LABELS_NOT_FOUND);
+
+        Bubble bubble;
+
+        // 기존 Bubble 수정 또는 새로운 Bubble 생성
+        if (bubbleRepository.existsById(request.getBubbleId())) {
+            bubble = updateExistingBubble(request, member, linkedBubble, labels);
+        } else {
+            bubble = createNewBubble(request, member, linkedBubble, labels);
+        }
+
+        // 결과 반환
+        List<LabelResponseDTO.CreateResultDto> labelDtos = bubble.getLabels().stream()
+                .map(bl -> LabelResponseDTO.CreateResultDto.builder()
+                        .labelId(bl.getLabel().getLabelId())
+                        .name(bl.getLabel().getName())
+                        .color(bl.getLabel().getColor())
+                        .build())
+                .collect(Collectors.toList());
+
+        return BubbleResponseDto.SyncResultDto.builder()
+                .bubbleId(bubble.getBubbleId())
+                .title(bubble.getTitle())
+                .content(bubble.getContent())
+                .mainImageUrl(bubble.getMainImg())
+                .labels(labelDtos)
+                .linkedBubbleId(Optional.ofNullable(bubble.getLinkedBubble())
+                        .map(Bubble::getBubbleId)
+                        .orElse(null))
+                .isDeleted(bubble.isDeleted())
+                .createdAt(bubble.getCreatedAt())
+                .updatedAt(bubble.getUpdatedAt())
+                .deletedAt(bubble.getDeletedAt())
+                .build();
+    }
+
     private int countOccurrences(String content, String keyword) {
         if (content == null || keyword == null || keyword.isEmpty()) return 0;
         int count = 0;
@@ -445,5 +504,55 @@ public class BubbleServiceImpl implements BubbleService {
             idx = content.indexOf(keyword, idx + keyword.length());
         }
         return count;
+    }
+
+    private Bubble updateExistingBubble(BubbleRequestDto.SyncDto request, Member member, Bubble linkedBubble, Set<Label> labels) {
+        Bubble bubble = bubbleRepository.findById(request.getBubbleId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
+
+        if(!bubble.getMember().getMemberId().equals(member.getMemberId())) {
+            throw new GeneralException(ErrorStatus._FORBIDDEN);
+        }
+
+        Set<BubbleLabel> bubbleLabels = labels.stream()
+                .map(label -> BubbleLabel.builder().bubble(bubble).label(label).build())
+                .collect(Collectors.toSet());
+
+        bubble.update(request.getTitle(), request.getContent(), request.getMainImageUrl(), linkedBubble, bubbleLabels);
+        bubble.setDeleted(request.isDeleted());
+        bubble.setUpdatedAt(request.getUpdatedAt());
+        bubble.setDeletedAt(request.getDeletedAt());
+
+        bubbleRepository.save(bubble);
+        bubbleLabelRepository.saveAll(bubbleLabels);
+        return bubble;
+    }
+
+    private Bubble createNewBubble(BubbleRequestDto.SyncDto request, Member member, Bubble linkedBubble, Set<Label> labels) {
+        Bubble newBubble = Bubble.builder()
+                .bubbleId(request.getBubbleId())
+                .title(request.getTitle())
+                .content(request.getContent())
+                .mainImg(request.getMainImageUrl())
+                .linkedBubble(linkedBubble)
+                .member(member)
+                .labels(new HashSet<>())
+                .isDeleted(request.isDeleted())
+                .createdAt(request.getCreatedAt())
+                .updatedAt(request.getUpdatedAt())
+                .deletedAt(request.getDeletedAt())
+                .build();
+
+        Bubble savedBubble = bubbleRepository.save(newBubble);
+
+        Set<BubbleLabel> bubbleLabels = labels.stream()
+                .map(label -> BubbleLabel.builder().bubble(savedBubble).label(label).build())
+                .collect(Collectors.toSet());
+
+        bubbleLabelRepository.saveAll(bubbleLabels);
+
+        savedBubble.getLabels().addAll(bubbleLabels);
+
+        return newBubble;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -524,7 +524,6 @@ public class BubbleServiceImpl implements BubbleService {
         bubble.setDeletedAt(request.getDeletedAt());
 
         bubbleRepository.save(bubble);
-        bubbleLabelRepository.saveAll(bubbleLabels);
         return bubble;
     }
 

--- a/project/src/main/java/com/edison/project/global/common/entity/BaseEntity.java
+++ b/project/src/main/java/com/edison/project/global/common/entity/BaseEntity.java
@@ -17,14 +17,14 @@ public abstract class BaseEntity {
 
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
-    private LocalDateTime createdAt;
+    protected LocalDateTime createdAt;
 
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
-    private LocalDateTime updatedAt;
+    protected LocalDateTime updatedAt;
 
     @Column(name = "deleted_at", nullable = true)
-    private LocalDateTime deletedAt;
+    protected LocalDateTime deletedAt;
 
     @PrePersist
     public void prePersist() {
@@ -35,5 +35,17 @@ public abstract class BaseEntity {
     @PreUpdate
     public void preUpdate() {
         this.updatedAt = LocalDateTime.now();
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public LocalDateTime getUpdatedAt() {
+        return updatedAt;
+    }
+
+    public LocalDateTime getDeletedAt() {
+        return deletedAt;
     }
 }


### PR DESCRIPTION
.## #⃣ 연관된 이슈

> close #98 

## 📝 작업 내용

- 로컬 DB에서 버블 생성, 수정, 삭제(soft-delete)가 이루어진 데이터들을 받아와서 서버 DB에서 SYNC 맞춰 저장하는 기능입니다.
- 서버 DB에 해당 버블 ID가 없는 경우 -> 생성
- 서버 DB에 해당 버블 ID가 있는 경우 -> 수정
- 위 두 경우에서 isDeleted가 true인 경우, soft-delete가 동시 발생(=수정)
<img width="525" alt="image" src="https://github.com/user-attachments/assets/a9daf4c7-7a66-4e28-bddb-7857a2a5706f" />


### 📸 스크린샷 (선택)
- createdAt, updatedAt이 BaseEntity 설정으로 입력값에 상관없이 DB에 생성된(수정된) 시간으로 덮어씌워지는 경우가 발생하여, Bubble 엔티티의 경우 BaseEntity extends가 아닌, 버블 엔티티 내 일반 컬럼으로 수정하여 해결하였습니다.
<img width="637" alt="image" src="https://github.com/user-attachments/assets/d57e568c-8e82-4a5e-acf2-d5210de9aaf8" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- 세 경우가 모두 잘 작동하는지, createdAt, updatedAt이 DB 상에서도 입력값으로 잘 저장이 되는 지 확인 부탁드려용
