### PR TITLE
❕[!HOTFIX] #104: 버블 SYNC HardDelete 추가 구현

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -44,7 +44,7 @@ public enum ErrorStatus {
 
     // 버블 관련 애러
     BUBBLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BUBBLE4001", "버블을 찾을 수 없습니다."),
-
+    LINKEDBUBBLE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BUBBLE4002", "링크버블을 찾을 수 없습니다."),
     LABELS_TOO_MANY(HttpStatus.BAD_REQUEST, "BUBBLE_LABEL4001", "라벨 개수는 최대 3개까지 가능합니다."),
 
     // 라벨 관련 에러

--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -26,6 +26,7 @@ import org.springframework.data.domain.Pageable;
 public class BubbleRestController {
     private final BubbleService bubbleService;
 
+    /*
     // 버블 생성
     @PostMapping
     @PreAuthorize("isAuthenticated()")
@@ -53,6 +54,7 @@ public class BubbleRestController {
         BubbleResponseDto.RestoreResultDto result = bubbleService.restoreBubble(userPrincipal, bubbleId);
         return ApiResponse.onSuccess(SuccessStatus._OK, result);
     }
+    */
 
     // 버블 전체 목록 조회
     @GetMapping("/space")
@@ -136,6 +138,7 @@ public class BubbleRestController {
         return ApiResponse.onSuccess(SuccessStatus._OK);
     }
 
+    /*
     // 버블 수정
     @PatchMapping("/{bubbleId}")
     @PreAuthorize("isAuthenticated()")
@@ -147,6 +150,7 @@ public class BubbleRestController {
         BubbleResponseDto.ListResultDto response = bubbleService.updateBubble(userPrincipal, bubbleId, request);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
+     */
 
     // 버블 SYNC
     @PostMapping("/sync")

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -59,12 +59,18 @@ public class BubbleRequestDto {
         @NotNull(message = "(DTO)삭제 여부는 필수입니다.")
         @JsonProperty("isDeleted")
         private boolean isDeleted;
+
+        @JsonProperty("isTrashed")
+        private boolean isTrashed;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;
 
         public boolean isDeleted() {
             return isDeleted;
+        }
+        public boolean isTrashed() {
+            return isTrashed;
         }
     }
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -70,6 +70,7 @@ public class BubbleResponseDto {
         private List<LabelResponseDTO.CreateResultDto> labels;
         private Long linkedBubbleId;
         private Boolean isDeleted;
+        private Boolean isTrashed;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
         private LocalDateTime deletedAt;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -28,9 +28,9 @@ public class BubbleResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class DeleteResultDto {
+    public static class TrashResultDto {
         private Long bubbleId;
-        private boolean isDeleted;
+        private boolean isTrashed;
     }
 
     @Getter
@@ -46,7 +46,7 @@ public class BubbleResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class DeletedListResultDto {
+    public static class TrashedListResultDto {
         private Long bubbleId;
         private String title;
         private String content;

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -36,8 +36,8 @@ public class Bubble {
     @Column(name = "main_img", length = 2083)
     private String mainImg;
 
-    @Column(name = "is_deleted", nullable = false)
-    private boolean isDeleted = false;
+    @Column(name = "is_trashed", nullable = false)  //휴지통에 있는 지(soft_delete)
+    private boolean isTrashed = false;
 
     @Column(name = "created_at", nullable = false, updatable = false)
     protected LocalDateTime createdAt;
@@ -48,7 +48,6 @@ public class Bubble {
     @Column(name = "deleted_at", nullable = true)
     protected LocalDateTime deletedAt;
 
-
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "linked_bubble")
     private Bubble linkedBubble;
@@ -58,7 +57,7 @@ public class Bubble {
 
     @Builder
     public Bubble(Member member, Long bubbleId, String title, String content, String mainImg, Bubble linkedBubble, Set<BubbleLabel> labels,
-                  boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+                  boolean isTrashed, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         this.bubbleId = bubbleId;
         this.member = member;
         this.title = title;
@@ -68,7 +67,7 @@ public class Bubble {
         // 기존 라벨 초기화 후 새로운 라벨 추가
         this.labels.clear();
         this.labels.addAll(labels);
-        this.isDeleted = isDeleted;
+        this.isTrashed = isTrashed;
         this.setCreatedAt(createdAt);
         this.setUpdatedAt(updatedAt);
         this.setDeletedAt(deletedAt);
@@ -89,12 +88,12 @@ public class Bubble {
         this.labels = labels;
     }
 
-    public void setDeleted(boolean deleted) {
-        this.isDeleted = deleted;
+    public void setTrashed (boolean trashed) {
+        this.isTrashed = trashed;
     }
 
-    public boolean isDeleted() {
-        return isDeleted;
+    public boolean isTrashed() {
+        return isTrashed;
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleLabelRepository.java
@@ -14,7 +14,7 @@ public interface BubbleLabelRepository extends JpaRepository<BubbleLabel, Long> 
     @Query("SELECT b " +
             "FROM BubbleLabel bl " +
             "JOIN bl.bubble b " +
-            "WHERE bl.label.labelId = :labelId AND b.isDeleted = false")
+            "WHERE bl.label.labelId = :labelId AND b.isTrashed = false")
     List<Bubble> findBubblesByLabelId(@Param("labelId") Long labelId);
 
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -18,16 +18,16 @@ import java.util.Optional;
 public interface BubbleRepository extends JpaRepository<Bubble, Long> {
 
     // 삭제되지 않은 Bubble만 조회
-    Optional<Bubble> findByBubbleIdAndIsDeletedFalse(Long bubbleId);
+    Optional<Bubble> findByBubbleIdAndIsTrashedFalse(Long bubbleId);
 
     // 휴지통에 있는 Bubble만 조회
-    Optional<Bubble> findByBubbleIdAndIsDeletedTrue(Long bubbleId);
+    Optional<Bubble> findByBubbleIdAndIsTrashedTrue(Long bubbleId);
 
-    Page<Bubble> findByMember_MemberIdAndIsDeletedFalse(Long memberId, Pageable pageable);
-    Page<Bubble> findByMember_MemberIdAndIsDeletedTrue(Long memberId, Pageable pageable);
+    Page<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId, Pageable pageable);
+    Page<Bubble> findByMember_MemberIdAndIsTrashedTrue(Long memberId, Pageable pageable);
 
     // 7일 이내 버블 목록
-    @Query("SELECT b from Bubble b where b.member.memberId = :memberId AND b.isDeleted = false AND b.updatedAt >= :startDate")
+    @Query("SELECT b from Bubble b where b.member.memberId = :memberId AND b.isTrashed = false AND b.updatedAt >= :startDate")
     Page <Bubble> findRecentBubblesByMember(
             @Param("memberId") Long memberId,
             @Param("startDate") LocalDateTime startDate,
@@ -38,12 +38,12 @@ public interface BubbleRepository extends JpaRepository<Bubble, Long> {
     @Query("SELECT b FROM Bubble b " +
             "WHERE (b.title LIKE %:keyword% OR b.content LIKE %:keyword% " +
             "OR EXISTS (SELECT 1 FROM BubbleLabel bl WHERE bl.bubble = b AND bl.label.name LIKE %:keyword%)) " +
-            "AND b.isDeleted = false")
+            "AND b.isTrashed = false")
     List<Bubble> searchBubblesByKeyword(@Param("keyword") String keyword);
 
     // 30일 지난 휴지통 버블 목록
-    @Query("SELECT b from Bubble b where b.updatedAt < :expiryDate and b.isDeleted = true")
-    List<Bubble> findAllByUpdatedAtBeforeAndIsDeletedTrue(@Param("expiryDate") LocalDateTime expiryDate);
+    @Query("SELECT b from Bubble b where b.updatedAt < :expiryDate and b.isTrashed = true")
+    List<Bubble> findAllByUpdatedAtBeforeAndIsTrashedTrue(@Param("expiryDate") LocalDateTime expiryDate);
 
     @Modifying
     @Transactional

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
@@ -11,13 +11,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.data.domain.Pageable;
 
 public interface BubbleService {
-    BubbleResponseDto.ListResultDto createBubble(CustomUserPrincipal userPrincipal, BubbleRequestDto.ListDto requestDto);
+    //BubbleResponseDto.ListResultDto createBubble(CustomUserPrincipal userPrincipal, BubbleRequestDto.ListDto requestDto);
 
-    BubbleResponseDto.DeleteResultDto deleteBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
+    //BubbleResponseDto.DeleteResultDto deleteBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
 
-    BubbleResponseDto.RestoreResultDto restoreBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
+    //BubbleResponseDto.RestoreResultDto restoreBubble(CustomUserPrincipal userPrincipal, Long bubbleId);
 
-    BubbleResponseDto.ListResultDto updateBubble(CustomUserPrincipal userPrincipal, Long bubbleId, BubbleRequestDto.ListDto requestDto);
+    //BubbleResponseDto.ListResultDto updateBubble(CustomUserPrincipal userPrincipal, Long bubbleId, BubbleRequestDto.ListDto requestDto);
 
     ResponseEntity<ApiResponse> getDeletedBubbles(CustomUserPrincipal userPrincipal, Pageable pageable);
 

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -463,15 +463,11 @@ public class BubbleServiceImpl implements BubbleService {
 
         Bubble bubble;
 
-        // 기존 Bubble 수정 또는 새로운 Bubble 생성
-        if (bubbleRepository.existsById(request.getBubbleId())) {
-            if (request.isTrashed()) {
-                bubble = hardDeleteBubble(request, member);
-            } else {
-                bubble = updateExistingBubble(request, member, linkedBubble, labels);
-            }
+
+        if (request.isTrashed()) {
+            bubble = bubbleRepository.existsById(request.getBubbleId()) ? hardDeleteBubble(request, member) : null;
         } else {
-            bubble = createNewBubble(request, member, linkedBubble, labels);
+            bubble =  bubbleRepository.existsById(request.getBubbleId()) ? updateExistingBubble(request, member, linkedBubble, labels) : createNewBubble(request, member, linkedBubble, labels);
         }
 
         if (!request.isTrashed()) {

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -74,6 +74,7 @@ public class BubbleServiceImpl implements BubbleService {
                 .build();
     }
 
+    /*
     @Override
     @Transactional
     public BubbleResponseDto.ListResultDto createBubble(CustomUserPrincipal userPrincipal, BubbleRequestDto.ListDto requestDto) {
@@ -122,7 +123,7 @@ public class BubbleServiceImpl implements BubbleService {
 
     @Override
     @Transactional
-    public BubbleResponseDto.DeleteResultDto deleteBubble(CustomUserPrincipal userPrincipal, Long bubbleId) {
+    public BubbleResponseDto.TrashedResultDto deleteBubble(CustomUserPrincipal userPrincipal, Long bubbleId) {
         if (userPrincipal == null) {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
@@ -135,12 +136,12 @@ public class BubbleServiceImpl implements BubbleService {
         if (!bubble.getMember().getMemberId().equals(userPrincipal.getMemberId())) {
         }
 
-        bubble.setDeleted(true);
+        bubble.setTrashed(true);
         bubbleRepository.save(bubble);
 
         return BubbleResponseDto.DeleteResultDto.builder()
                 .bubbleId(bubble.getBubbleId())
-                .isDeleted(bubble.isDeleted())
+                .isDeleted(bubble.isTrashed())
                 .build();
     }
 
@@ -161,12 +162,12 @@ public class BubbleServiceImpl implements BubbleService {
             throw new GeneralException(ErrorStatus._FORBIDDEN);
         }
 
-        bubble.setDeleted(false);
+        bubble.setTrashed(false);
         bubbleRepository.save(bubble);
 
         return BubbleResponseDto.RestoreResultDto.builder()
                 .bubbleId(bubble.getBubbleId())
-                .isRestored(!bubble.isDeleted())
+                .isRestored(!bubble.isTrashed())
                 .build();
     }
 
@@ -213,6 +214,7 @@ public class BubbleServiceImpl implements BubbleService {
 
         return convertToBubbleResponseDto(bubble);
     }
+    */
 
     @Override
     @Transactional
@@ -221,7 +223,7 @@ public class BubbleServiceImpl implements BubbleService {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
-        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberIdAndIsDeletedFalse(userPrincipal.getMemberId(), pageable);
+        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberIdAndIsTrashedFalse(userPrincipal.getMemberId(), pageable);
 
         PageInfo pageInfo = new PageInfo(bubblePage.getNumber(), bubblePage.getSize(), bubblePage.hasNext(),
                 bubblePage.getTotalElements(), bubblePage.getTotalPages());
@@ -244,14 +246,14 @@ public class BubbleServiceImpl implements BubbleService {
         Member member = memberRepository.findById(userPrincipal.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberIdAndIsDeletedTrue(userPrincipal.getMemberId(), pageable);
+        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberIdAndIsTrashedTrue(userPrincipal.getMemberId(), pageable);
 
         PageInfo pageInfo = new PageInfo(bubblePage.getNumber(), bubblePage.getSize(), bubblePage.hasNext(),
                 bubblePage.getTotalElements(), bubblePage.getTotalPages());
 
         // Bubble 데이터 변환
         // Bubble -> DeletedListResultDto 변환
-        List<BubbleResponseDto.DeletedListResultDto> bubbles = bubblePage.getContent().stream()
+        List<BubbleResponseDto.TrashedListResultDto> bubbles = bubblePage.getContent().stream()
                 .map(bubble -> {
                     LocalDateTime updatedAt = bubble.getUpdatedAt();
                     LocalDateTime now = LocalDateTime.now();
@@ -266,7 +268,7 @@ public class BubbleServiceImpl implements BubbleService {
                                     .build())
                             .collect(Collectors.toList());
 
-                    return BubbleResponseDto.DeletedListResultDto.builder()
+                    return BubbleResponseDto.TrashedListResultDto.builder()
                             .bubbleId(bubble.getBubbleId())
                             .title(bubble.getTitle())
                             .content(bubble.getContent())
@@ -319,7 +321,7 @@ public class BubbleServiceImpl implements BubbleService {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
-        Bubble bubble = bubbleRepository.findByBubbleIdAndIsDeletedFalse(bubbleId).orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
+        Bubble bubble = bubbleRepository.findByBubbleIdAndIsTrashedFalse(bubbleId).orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
 
         // 조회 권한 확인
         if (!bubble.getMember().getMemberId().equals(userPrincipal.getMemberId())) {
@@ -397,7 +399,7 @@ public class BubbleServiceImpl implements BubbleService {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
-        Bubble bubble = bubbleRepository.findByBubbleIdAndIsDeletedTrue(bubbleId)
+        Bubble bubble = bubbleRepository.findByBubbleIdAndIsTrashedTrue(bubbleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
 
         // 권한 확인
@@ -420,7 +422,7 @@ public class BubbleServiceImpl implements BubbleService {
         LocalDateTime now = LocalDateTime.now();
         LocalDateTime expiryDate = now.minusDays(30);
 
-        List<Bubble> expiredBubbles = bubbleRepository.findAllByUpdatedAtBeforeAndIsDeletedTrue(expiryDate);
+        List<Bubble> expiredBubbles = bubbleRepository.findAllByUpdatedAtBeforeAndIsTrashedTrue(expiryDate);
 
         if (!expiredBubbles.isEmpty()) {
             List<Long> bubbleIds = expiredBubbles.stream()
@@ -464,13 +466,13 @@ public class BubbleServiceImpl implements BubbleService {
         Bubble bubble;
 
 
-        if (request.isTrashed()) {
+        if (request.isDeleted()) {
             bubble = bubbleRepository.existsById(request.getBubbleId()) ? hardDeleteBubble(request, member) : null;
         } else {
             bubble =  bubbleRepository.existsById(request.getBubbleId()) ? updateExistingBubble(request, member, linkedBubble, labels) : createNewBubble(request, member, linkedBubble, labels);
         }
 
-        if (!request.isTrashed()) {
+        if (!request.isDeleted()) {
             // 결과 반환
             List<LabelResponseDTO.CreateResultDto> labelDtos = bubble.getLabels().stream()
                     .map(bl -> LabelResponseDTO.CreateResultDto.builder()
@@ -489,8 +491,8 @@ public class BubbleServiceImpl implements BubbleService {
                     .linkedBubbleId(Optional.ofNullable(bubble.getLinkedBubble())
                             .map(Bubble::getBubbleId)
                             .orElse(null))
-                    .isDeleted(bubble.isDeleted())
-                    .isTrashed(request.isTrashed())
+                    .isDeleted(request.isDeleted())
+                    .isTrashed(bubble.isTrashed())
                     .createdAt(bubble.getCreatedAt())
                     .updatedAt(bubble.getUpdatedAt())
                     .deletedAt(bubble.getDeletedAt())
@@ -503,8 +505,8 @@ public class BubbleServiceImpl implements BubbleService {
                     .mainImageUrl(null)
                     .labels(null)
                     .linkedBubbleId(null)
-                    .isDeleted(null)
-                    .isTrashed(request.isTrashed())
+                    .isDeleted(request.isDeleted())
+                    .isTrashed(null)
                     .createdAt(null)
                     .updatedAt(null)
                     .deletedAt(null)
@@ -536,12 +538,9 @@ public class BubbleServiceImpl implements BubbleService {
                 .collect(Collectors.toSet());
 
         bubble.update(request.getTitle(), request.getContent(), request.getMainImageUrl(), linkedBubble, bubbleLabels);
-        bubble.setDeleted(request.isDeleted());
+        bubble.setTrashed(request.isTrashed());
         bubble.setUpdatedAt(request.getUpdatedAt());
         bubble.setDeletedAt(request.getDeletedAt());
-
-        System.out.println("Request isDeleted: " + request.isDeleted());
-        System.out.println("Before Update Bubble isDeleted: " + bubble.isDeleted());
 
         bubbleRepository.saveAndFlush(bubble);
         return bubble;
@@ -573,7 +572,7 @@ public class BubbleServiceImpl implements BubbleService {
                 .linkedBubble(linkedBubble)
                 .member(member)
                 .labels(new HashSet<>())
-                .isDeleted(request.isDeleted())
+                .isTrashed(request.isTrashed())
                 .createdAt(request.getCreatedAt())
                 .updatedAt(request.getUpdatedAt())
                 .deletedAt(request.getDeletedAt())

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -12,7 +12,7 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
     // 특정 사용자의 모든 라벨 정보와 & 라벨별 버블 개수 조회
     @Query("SELECT l, COUNT(bl.bubble) " +
             "FROM Label l " +
-            "LEFT JOIN BubbleLabel bl ON l.labelId = bl.label.labelId AND bl.bubble.isDeleted = false " +
+            "LEFT JOIN BubbleLabel bl ON l.labelId = bl.label.labelId AND bl.bubble.isTrashed = false " +
             "WHERE l.member.memberId = :memberId " +
             "GROUP BY l")
     List<Object[]> findLabelInfoByMemberId(@Param("memberId") Long memberId);

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -308,6 +308,7 @@ public class MemberServiceImpl implements MemberService{
         return ApiResponse.onSuccess(_OK);
     }
 
+    @Transactional
     public MemberResponseDto.IdentityTestSaveResultDto updateIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request) {
         if (userPrincipal == null) {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -309,6 +309,7 @@ public class MemberServiceImpl implements MemberService{
     }
 
     @Transactional
+    @Override
     public MemberResponseDto.IdentityTestSaveResultDto updateIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request) {
         if (userPrincipal == null) {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);


### PR DESCRIPTION
## #⃣ 연관된 이슈
> close #104 

## 📝 작업 내용

- 서버 DB에 해당 버블 ID가 없는 경우 -> 생성
- 서버 DB에 해당 버블 ID가 있는 경우 -> 수정
- 위 두 경우에서 isTrashed가 true인 경우, soft-delete가 동시 발생(=수정)
- isDeleted가 true인 경우 → 삭제 ✔️ 요부분까지 작동하도록 업데이트
- 엔티티 수정 (trashed - softdelete, deleted - harddelete)
<img width="225" alt="image" src="https://github.com/user-attachments/assets/fa36366d-6802-4e28-8f3a-c9539d77c968" />


### 📸 스크린샷 (선택)
- 새로운 버블 & isDeleted = false -> 생성
<img width="567" alt="image" src="https://github.com/user-attachments/assets/4feb67bd-1a2c-4dcf-bb0d-c0e72d981f86" />


- 존재하는 버블 & isDeleted = false -> 수정
<img width="536" alt="image" src="https://github.com/user-attachments/assets/7f25c9e0-1f51-4497-ae5b-6baf461a43ac" />

- 새로운 버블 & isDeleted = true -> db에 저장 안 하고 바로 결과 반환
- 존재하는 버블 & isDeleted = true -> 삭제
<img width="539" alt="image" src="https://github.com/user-attachments/assets/f8b9bbb7-03d7-4187-a0ce-94531923f208" />



## 💬 리뷰 요구사항(선택)

> 서버 디비에 없는 아이디가 isDeleted = true인 상태로 넘어왔을 때(로컬에서 생성->harddelete까지 된 후 넘어온 상태), db에는 아예 안 저장되고 결과 반환 아래와 같이 잘 되는 지 확인해주세용
<img width="492" alt="image" src="https://github.com/user-attachments/assets/3e0bc16e-5d68-48f7-b30d-79175f02d38d" />

