### PR TITLE
❕ [!HOTFIX] #105 라벨 SYNC 삭제 로직 응답DTO 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -140,7 +140,11 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
             return LabelResponseDTO.LabelSyncResponseDTO.builder()
                     .labelId(request.getLabelId())
+                    .name(request.getName())
+                    .color(request.getColor())
                     .isDeleted(true)
+                    .createdAt(request.getCreatedAt())
+                    .updatedAt(request.getUpdatedAt())
                     .deletedAt(label.getDeletedAt())
                     .build();
         }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -126,9 +126,21 @@ public class LabelQueryServiceImpl implements LabelQueryService {
         Label label;
 
         if (Boolean.TRUE.equals(request.getIsDeleted())) {
+            // 존재하지 않는 라벨 ID의 삭제 요청 -> 에러 대신 요청값 그대로 반환
+            if (!labelRepository.existsById(request.getLabelId())) {
+                return LabelResponseDTO.LabelSyncResponseDTO.builder()
+                        .labelId(request.getLabelId())
+                        .name(request.getName())
+                        .color(request.getColor())
+                        .isDeleted(true)
+                        .createdAt(request.getCreatedAt())
+                        .updatedAt(request.getUpdatedAt())
+                        .deletedAt(request.getDeletedAt())
+                        .build();
+            }
+
             // 라벨 삭제(hard delete)
-            label = labelRepository.findById(request.getLabelId())
-                    .orElseThrow(() -> new GeneralException(ErrorStatus.LABELS_NOT_FOUND));
+            label = labelRepository.findById(request.getLabelId()).get();
 
             if (!label.getMember().getMemberId().equals(userPrincipal.getMemberId())) {
                 throw new GeneralException(ErrorStatus._FORBIDDEN);


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #105 

## 📝 작업 내용

>라벨 sync api의 삭제 로직에서, id와 isDeleted 필드의 값을 제외한 다른 필드의 값들도 null이 아니라 정상적으로 출력되도록 수정하였습니다.

### 📸 스크린샷 (선택)
- 수정 후
<img width="652" alt="image" src="https://github.com/user-attachments/assets/22637219-4c6d-48a7-87bb-c10a5324eb00" />


## 💬 리뷰 요구사항(선택)

> localhost:8080/labels/sync(혹은 서버주소) 에서, isDeleted=true로 라벨 삭제 진행 시, name/color/시간 필드들의 값이 null이 아니라 요청값 그대로 잘 출력되는지만 확인해주세요!