### PR TITLE
✨[FEAT] #103 프로필 회원 정보 조회 API

### DIFF
--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -72,4 +72,12 @@ public class MemberRestController {
         return ApiResponse.onSuccess(SuccessStatus._OK, result);
     }
 
+    @GetMapping
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> getMember(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        return memberService.getMember(userPrincipal);
+    }
+
+
 }

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
@@ -73,4 +73,18 @@ public class MemberResponseDto {
     public static class IdentityKeywordsResultDto {
         private Map<String, List<IdentityKeywordDto>> categories;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemberResultDto {
+
+        private String email;
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        private String nickname;
+
+        private String profileImg;
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
@@ -17,4 +17,5 @@ public interface MemberService {
     MemberResponseDto.IdentityKeywordsResultDto getIdentityKeywords(CustomUserPrincipal userPrincipal);
     ResponseEntity<ApiResponse> cancel(CustomUserPrincipal userPrincipal);
     MemberResponseDto.IdentityTestSaveResultDto updateIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
+    ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal);
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -96,6 +96,7 @@ public class MemberServiceImpl implements MemberService{
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
+
         Member member = memberRepository.findById(userPrincipal.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
@@ -190,10 +191,10 @@ public class MemberServiceImpl implements MemberService{
 
     @Override
     @Transactional
-    public ResponseEntity<ApiResponse> refreshAccessToken(String refreshToken) {
+    public ResponseEntity<ApiResponse> refreshAccessToken(String refreshtoken) {
 
-        Long memberId = jwtUtil.extractUserId(refreshToken);
-        String email = jwtUtil.extractEmail(refreshToken);
+        Long memberId = jwtUtil.extractUserId(refreshtoken);
+        String email = jwtUtil.extractEmail(refreshtoken);
 
         String newAccessToken = jwtUtil.generateAccessToken(memberId, email);
 
@@ -377,5 +378,21 @@ public class MemberServiceImpl implements MemberService{
                 .build();
     }
 
+    @Override
+    @Transactional
+    public ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal) {
+
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        MemberResponseDto.MemberResultDto response = MemberResponseDto.MemberResultDto.builder()
+                .email(userPrincipal.getEmail())
+                .nickname(member.getNickname())
+                .profileImg(member.getProfileImg())
+                .build();
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+
+    }
 
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #103 

## 📝 작업 내용

> 마이페이지창에 보이는 회원 정보(닉네임, 이메일, 프로필사진)를 가져오는 API입니다.

### 📸 스크린샷 (선택)
<img width="613" alt="스크린샷 2025-02-02 오전 12 24 33" src="https://github.com/user-attachments/assets/e7bba0ba-28e4-4b31-824f-4741806dc194" />
<img width="616" alt="스크린샷 2025-02-02 오전 12 24 44" src="https://github.com/user-attachments/assets/414748ee-8c46-4670-ab18-615099082725" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
