### PR TITLE
feat: 카테고리별 스크랩한 아트레터 조회 및 카테고리에 해당하는 스크랩 아트레터 조회 api

### DIFF
--- a/project/src/main/java/com/edison/project/common/exception/ExceptionAdvice.java
+++ b/project/src/main/java/com/edison/project/common/exception/ExceptionAdvice.java
@@ -4,10 +4,13 @@ import com.edison.project.common.response.ApiResponse;
 import com.edison.project.common.status.ErrorStatus;
 import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.convert.ConversionFailedException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.ErrorResponse;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 @Slf4j
@@ -52,4 +55,8 @@ public class ExceptionAdvice {
         return ApiResponse.onFailure(e.getErrorStatus(), e.getMessage());
     }
 
+    @ExceptionHandler({MethodArgumentTypeMismatchException.class, ConversionFailedException.class})
+    public ResponseEntity<ApiResponse> handleConversionFailedException(Exception e) {
+        return ApiResponse.onFailure((ErrorStatus.NOT_EXISTS_CATEGORY));
+    }
 }

--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -69,6 +69,7 @@ public enum ErrorStatus {
     ARTLETTER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "LETTER4010", "아트레터 ID를 입력해 주세요."),
     LETTERS_NOT_FOUND(HttpStatus.BAD_REQUEST, "LETTER4011", "아트레터를 찾을 수 없습니다."),
     NOT_EXISTS_CATEGORY(HttpStatus.BAD_REQUEST, "LETTER4012", "존재하지 않는 아트레터 카테고리입니다."),
+    ARTLETTER_NOT_FOUND(HttpStatus.BAD_REQUEST, "LETTER4012", "스크랩한 아트레터가 없습니다."),
 
     // 검색 관련 에러
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH4001", "검색어는 공백일 수 없습니다.");

--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -68,6 +68,7 @@ public enum ErrorStatus {
     KEYWORD_IS_EMPTY(HttpStatus.BAD_REQUEST, "LETTER4009", "keyword field 관련 오류"),
     ARTLETTER_ID_REQUIRED(HttpStatus.BAD_REQUEST, "LETTER4010", "아트레터 ID를 입력해 주세요."),
     LETTERS_NOT_FOUND(HttpStatus.BAD_REQUEST, "LETTER4011", "아트레터를 찾을 수 없습니다."),
+    NOT_EXISTS_CATEGORY(HttpStatus.BAD_REQUEST, "LETTER4012", "존재하지 않는 아트레터 카테고리입니다."),
 
     // 검색 관련 에러
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH4001", "검색어는 공백일 수 없습니다.");

--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -224,4 +224,25 @@ public class ArtletterController {
         List<ArtletterDTO.recommendKeywordDto> response = artletterService.getRecommendKeyword(artletterIds);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
+
+    @GetMapping("/scrap")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> getScrapArtlettersByCategory(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return artletterService.getScrapArtlettersByCategory(userPrincipal, pageable);
+    }
+
+    @GetMapping("/scrap/{category}")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> getScrapCategoryArtletters(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @PathVariable ArtletterCategory category,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        return artletterService.getScrapCategoryArtletters(userPrincipal, category, pageable);
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
@@ -130,5 +130,14 @@ public class ArtletterDTO {
         private Long artletterId;
         private ArtletterCategory category;
     }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GroupedScrapResponseDto {
+        private String category;
+        private List<MyScrapResponseDto> artletters;
+    }
 }
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -3,6 +3,7 @@ package com.edison.project.domain.artletter.service;
 import com.edison.project.common.response.ApiResponse;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.artletter.entity.ArtletterCategory;
 import com.edison.project.global.security.CustomUserPrincipal;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -33,5 +34,9 @@ public interface ArtletterService {
     List<ArtletterDTO.recommendKeywordDto> getRecommendKeyword(List<Long> artletterIds);
 
     List<ArtletterDTO.recommendCategoryDto> getRecommendCategory(List<Long> artletterIds);
+
+    ResponseEntity<ApiResponse> getScrapArtlettersByCategory(CustomUserPrincipal userPrincipal, Pageable pageable);
+
+    ResponseEntity<ApiResponse> getScrapCategoryArtletters(CustomUserPrincipal userPrincipal, ArtletterCategory category, Pageable pageable);
 
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -351,11 +351,15 @@ public class ArtletterServiceImpl implements ArtletterService {
         try {
             ArtletterCategory artletterCategory = ArtletterCategory.valueOf(String.valueOf(category));
         } catch (IllegalArgumentException e) {
-            System.out.println("밍밍");
             throw new GeneralException(ErrorStatus.NOT_EXISTS_CATEGORY);
         }
 
         Page<Scrap> scraps = scrapRepository.findByMemberAndArtletter_Category(member, category, pageable);
+
+//        // 스크랩한 아트레터가 없는 경우 예외 발생
+//        if (scraps.isEmpty() || scraps==null) {
+//            throw new GeneralException(ErrorStatus.ARTLETTER_NOT_FOUND);
+//        }
 
         PageInfo pageInfo = new PageInfo(
                 scraps.getNumber(),

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -7,6 +7,7 @@ import com.edison.project.common.status.ErrorStatus;
 import com.edison.project.common.status.SuccessStatus;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.artletter.entity.ArtletterCategory;
 import com.edison.project.domain.artletter.entity.ArtletterLikes;
 import com.edison.project.domain.artletter.repository.ArtletterLikesRepository;
 import com.edison.project.domain.artletter.repository.ArtletterRepository;
@@ -297,6 +298,93 @@ public class ArtletterServiceImpl implements ArtletterService {
         return artletters.stream()
                 .map(artletter -> new ArtletterDTO.recommendKeywordDto(artletter.getLetterId(),artletter.getKeyword()))
                 .collect(Collectors.toList());
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse> getScrapArtlettersByCategory(CustomUserPrincipal userPrincipal, Pageable pageable) {
+
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Page<Scrap> scraps = scrapRepository.findByMember(member, pageable);
+
+        PageInfo pageInfo = new PageInfo(
+                scraps.getNumber(),
+                scraps.getSize(),
+                scraps.hasNext(),
+                scraps.getTotalElements(),
+                scraps.getTotalPages()
+        );
+
+        // 카테고리별 그룹화
+        Map<String, List<Scrap>> groupedByCategory = scraps.getContent().stream()
+                .collect(Collectors.groupingBy(scrap -> String.valueOf(scrap.getArtletter().getCategory())));
+
+        // 그룹화된 데이터를 DTO 리스트로 변환
+        List<ArtletterDTO.GroupedScrapResponseDto> groupedArtletters = groupedByCategory.entrySet().stream()
+                .map(entry -> new ArtletterDTO.GroupedScrapResponseDto(
+                        entry.getKey(),
+                        entry.getValue().stream().map(scrap -> {
+                            Artletter artletter = scrap.getArtletter();
+                            int likesCnt = artletterLikesRepository.countByArtletter(artletter);
+                            int scrapsCnt = scrapRepository.countByArtletter(artletter);
+                            return ArtletterDTO.MyScrapResponseDto.builder()
+                                    .artletterId(artletter.getLetterId())
+                                    .title(artletter.getTitle())
+                                    .thumbnail(artletter.getThumbnail())
+                                    .likesCnt(likesCnt)
+                                    .scrapsCnt(scrapsCnt)
+                                    .scrappedAt(artletter.getCreatedAt())
+                                    .build();
+                        }).toList()
+                )).toList();
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, pageInfo, groupedArtletters);
+    }
+
+    @Override
+    public ResponseEntity<ApiResponse> getScrapCategoryArtletters(CustomUserPrincipal userPrincipal, ArtletterCategory category, Pageable pageable) {
+
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        try {
+            ArtletterCategory artletterCategory = ArtletterCategory.valueOf(String.valueOf(category));
+        } catch (IllegalArgumentException e) {
+            System.out.println("밍밍");
+            throw new GeneralException(ErrorStatus.NOT_EXISTS_CATEGORY);
+        }
+
+        Page<Scrap> scraps = scrapRepository.findByMemberAndArtletter_Category(member, category, pageable);
+
+        PageInfo pageInfo = new PageInfo(
+                scraps.getNumber(),
+                scraps.getSize(),
+                scraps.hasNext(),
+                scraps.getTotalElements(),
+                scraps.getTotalPages()
+        );
+
+        // DTO 변환 전에 엔티티 기준으로 카테고리별 그룹화
+        Map<String, List<Scrap>> groupedByCategory = scraps.getContent().stream()
+                .collect(Collectors.groupingBy(scrap -> String.valueOf(scrap.getArtletter().getCategory())));
+
+        List<ArtletterDTO.MyScrapResponseDto> artletters = scraps.getContent().stream()
+                .map(scrap -> {
+                    Artletter artletter = scrap.getArtletter();
+                    int likesCnt = artletterLikesRepository.countByArtletter(artletter);
+                    int scrapsCnt = scrapRepository.countByArtletter(artletter);
+                    return ArtletterDTO.MyScrapResponseDto.builder()
+                            .artletterId(artletter.getLetterId())
+                            .title(artletter.getTitle())
+                            .thumbnail(artletter.getThumbnail())
+                            .likesCnt(likesCnt)
+                            .scrapsCnt(scrapsCnt)
+                            .scrappedAt(artletter.getCreatedAt())
+                            .build();
+                }).toList();
+
+        return ApiResponse.onSuccess(SuccessStatus._OK, pageInfo, artletters);
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
+++ b/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
@@ -1,6 +1,7 @@
 package com.edison.project.domain.scrap.repository;
 
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.artletter.entity.ArtletterCategory;
 import com.edison.project.domain.member.entity.Member;
 import com.edison.project.domain.scrap.entity.Scrap;
 import jakarta.transaction.Transactional;
@@ -20,4 +21,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     void deleteByMemberAndArtletter(Member member, Artletter artletter);
 
     Page<Scrap> findByMember(Member member, Pageable pageable);
+
+    Page<Scrap> findByMemberAndArtletter_Category(Member member, ArtletterCategory category, Pageable pageable);
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #113 

## 📝 작업 내용

> 카테고리별 스크랩 아트레터 조회 api(회원이 스크랩한 모든 아트레터들을 조회하는데 같은 카테고리들은 묶여서 나옵니다!)
& 카테고리에 해당하는 스크랩 아트레터 조회 api(해당하는 카테고리의 아트레터들)를 구현했습니다! 

### 📸 스크린샷 (선택)
- 스크랩한 전체 아트레터 조회
<img width="647" alt="스크린샷 2025-02-07 오후 6 21 56" src="https://github.com/user-attachments/assets/358de5c6-b8ed-4486-9abd-231239faf45d" />

- 스크랩한 아트레터 중 해당하는 카테고리의 아트레터 조회
<img width="641" alt="스크린샷 2025-02-08 오후 10 26 19" src="https://github.com/user-attachments/assets/aae0b608-1912-4e4b-9b6c-c96fc466c797" />

- 존재하지 않는 카테고리로 요청한 경우
<img width="646" alt="스크린샷 2025-02-08 오후 10 40 38" src="https://github.com/user-attachments/assets/b3128643-a324-4658-804f-cdd54a10782d" />



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
