### PR TITLE
❕[!HOTFIX] #116:  필터에 토큰 없을 경우 예외처리추가

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -20,6 +20,7 @@ public enum ErrorStatus {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALID401", "입력값이 올바르지 않습니다."),
 
     // 로그인 관련 에러
+    CUSTOM_ENTRY_EXCEPTION(HttpStatus.UNAUTHORIZED, "LOGIN4000", "커스텀 엔트리 예외입니다."),
     LOGIN_CANCELLED(HttpStatus.BAD_REQUEST, "LOGIN4001", "로그인이 취소되었습니다."),
     LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "LOGIN4002", "로그인이 필요합니다."),
     INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "LOGIN4003", "유효하지 않은 토큰입니다."),

--- a/project/src/main/java/com/edison/project/global/security/CustomAuthenticationEntryPoint.java
+++ b/project/src/main/java/com/edison/project/global/security/CustomAuthenticationEntryPoint.java
@@ -1,40 +1,36 @@
 package com.edison.project.global.security;
 
+import com.edison.project.common.response.ApiResponse;
+import com.edison.project.common.status.ErrorStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
 
-    private final ObjectMapper objectMapper;
-
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
             throws IOException {
 
-        Map<String, Object> errorResponse = new HashMap<>();
-        errorResponse.put("isSuccess", false);
-        errorResponse.put("code", "LOGIN4000");
-        errorResponse.put("message", "커스텀 엔트리 예외입니다.");
+        ResponseEntity<ApiResponse> errorResponse = ApiResponse.onFailure(ErrorStatus.CUSTOM_ENTRY_EXCEPTION);
 
-        // 응답 설정
-        response.setContentType("application/json;charset=UTF-8"); // Content-Type + UTF-8 설정
-        response.setCharacterEncoding("UTF-8"); // 문자 인코딩 설정
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED); // 401 상태 코드
+        // HttpServletResponse에 직접 작성
+        response.setContentType("application/json;charset=UTF-8");
+        response.setCharacterEncoding("UTF-8");
+        response.setStatus(errorResponse.getStatusCode().value());
 
         // JSON 응답 반환
-        objectMapper.writeValue(response.getWriter(), errorResponse);
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.writeValue(response.getWriter(), errorResponse.getBody());
 
-        return;
     }
 }

--- a/project/src/main/java/com/edison/project/global/security/CustomAuthenticationEntryPoint.java
+++ b/project/src/main/java/com/edison/project/global/security/CustomAuthenticationEntryPoint.java
@@ -25,7 +25,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         Map<String, Object> errorResponse = new HashMap<>();
         errorResponse.put("isSuccess", false);
         errorResponse.put("code", "LOGIN4000");
-        errorResponse.put("message", "인증되지 않은 사용자입니다.");
+        errorResponse.put("message", "커스텀 엔트리 예외입니다.");
 
         // 응답 설정
         response.setContentType("application/json;charset=UTF-8"); // Content-Type + UTF-8 설정
@@ -34,5 +34,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
         // JSON 응답 반환
         objectMapper.writeValue(response.getWriter(), errorResponse);
+
+        return;
     }
 }

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -38,16 +38,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
             String authHeader = request.getHeader("Authorization");
 
-            if (authHeader != null && authHeader.startsWith("Bearer ")) {
-                String token = authHeader.substring(7);
+            if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+                throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
+            }
 
-                if (request.getRequestURI().equals("/members/refresh")) {
-                    // Refresh 요청 처리
-                    handleRefreshRequest(request, token);
-                } else {
-                    // 일반 요청 처리
-                    handleAccessTokenRequest(request, token);
-                }
+            String token = authHeader.substring(7);
+
+            if (request.getRequestURI().equals("/members/refresh")) {
+                // Refresh 요청 처리
+                handleRefreshRequest(request, token);
+            } else {
+                // 일반 요청 처리
+                handleAccessTokenRequest(request, token);
             }
 
             filterChain.doFilter(request, response);

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -1,19 +1,20 @@
 package com.edison.project.global.security;
 
 import com.edison.project.common.exception.GeneralException;
+import com.edison.project.common.response.ApiResponse;
 import com.edison.project.common.status.ErrorStatus;
 import com.edison.project.domain.member.entity.RefreshToken;
 import com.edison.project.domain.member.repository.MemberRepository;
 import com.edison.project.domain.member.repository.RefreshTokenRepository;
 import com.edison.project.domain.member.service.RedisTokenService;
 import com.edison.project.global.util.JwtUtil;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
@@ -54,13 +55,17 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             filterChain.doFilter(request, response);
         } catch (GeneralException e) {
-            // Custom Exception 처리
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-            response.setContentType("application/json");
-            response.setCharacterEncoding("UTF-8");
-            response.getWriter().write("{\"isSuccess\":false,\"code\":\"" + e.getErrorStatus().getCode() + "\",\"message\":\"" + e.getErrorStatus().getMessage() + "\"}");
-        }
 
+            if (!response.isCommitted()) {
+                response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                response.setContentType("application/json");
+                response.setCharacterEncoding("UTF-8");
+
+                ObjectMapper objectMapper = new ObjectMapper();
+                objectMapper.writeValue(response.getWriter(), ApiResponse.onFailure(e.getErrorStatus()).getBody());
+            }
+
+        }
     }
 
     private void handleAccessTokenRequest(HttpServletRequest request, String token) {


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #116 

## 📝 작업 내용

> 헤더에 토큰이 없거나 Bearer 형식이 맞지 않는 경우 커스텀 엔트리 페이지로 넘어가서 에러처리
-> JwtAuthenticationFilter에서 예외가 터지는 방식으로 바꿨습니다! 

### 📸 스크린샷 (선택)
<img width="653" alt="스크린샷 2025-02-10 오후 12 35 27" src="https://github.com/user-attachments/assets/102e9cad-7f21-4df6-b60b-929116eb3fef" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 이제 api에서 토큰이 없으면 위의 사진과 같은 에러가 나는지 확인해주시면 감사하겠습니다~!
