### PR TITLE
❕[!HOTFIX] #114: 구글로그인 토큰발급 방식 변경

### DIFF
--- a/project/build.gradle
+++ b/project/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'com.auth0:java-jwt:4.2.1'
+	implementation 'com.google.api-client:google-api-client:1.33.0'
+	implementation 'com.google.http-client:google-http-client-gson:1.39.2'
 
 	//로그아웃
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'

--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -79,5 +79,9 @@ public class MemberRestController {
         return memberService.getMember(userPrincipal);
     }
 
+    @PostMapping("/google")
+    public ResponseEntity<ApiResponse> googleCallback(@RequestBody MemberRequestDto.GoogleLoginDto request) {
+        return memberService.processGoogleLogin(request.getIdToken());
+    }
 
 }

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
@@ -50,5 +50,13 @@ public class MemberRequestDto {
 
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GoogleLoginDto{
+        private String idToken;
+    }
+
 
 }

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
@@ -16,8 +16,11 @@ public class MemberResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LoginResultDto{
-        String accessToken;
-        String refreshToken;
+
+        private Long memberId;
+        private String email;
+        private String accessToken;
+        private String refreshToken;
     }
 
     @Builder
@@ -45,7 +48,7 @@ public class MemberResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RefreshResultDto{
-        String accessToken;
+        private String accessToken;
     }
 
     @Builder

--- a/project/src/main/java/com/edison/project/domain/member/entity/Member.java
+++ b/project/src/main/java/com/edison/project/domain/member/entity/Member.java
@@ -46,6 +46,10 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Label> labels = new ArrayList<>();
 
+    public Member(String email) {
+        super();
+    }
+
     //복사 빌더 메서드
     public Member registerProfile(String nickname) {
         return Member.builder()

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
@@ -18,4 +18,5 @@ public interface MemberService {
     ResponseEntity<ApiResponse> cancel(CustomUserPrincipal userPrincipal);
     MemberResponseDto.IdentityTestSaveResultDto updateIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
     ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal);
+    ResponseEntity<ApiResponse> processGoogleLogin(String authorizationCode);
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -17,17 +17,12 @@ import com.edison.project.global.security.CustomUserPrincipal;
 import com.edison.project.global.util.JwtUtil;
 import com.google.api.client.googleapis.auth.oauth2.GoogleIdToken;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.edison.project.domain.member.entity.Member;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
-import org.springframework.web.client.RestTemplate;
-
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -44,14 +39,6 @@ public class MemberServiceImpl implements MemberService{
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtUtil jwtUtil;
     private final RedisTokenService redisTokenService;
-    private final RestTemplate restTemplate;
-
-    private static final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
-    @Value("${google.client.id}")
-    private String googleClientId;
-
-    @Value("${google.client.secret}")
-    private String googleClientSecret;
 
     @Override
     @Transactional

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -53,6 +53,8 @@ public class MemberServiceImpl implements MemberService{
             refreshTokenRepository.save(tokenEntity);
 
             return MemberResponseDto.LoginResultDto.builder()
+                    .memberId(memberId)
+                    .email(email)
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
                     .build();
@@ -68,6 +70,8 @@ public class MemberServiceImpl implements MemberService{
             refreshTokenRepository.save(tokenEntity);
 
              return MemberResponseDto.LoginResultDto.builder()
+                     .memberId(memberId)
+                     .email(email)
                     .accessToken(accessToken)
                     .refreshToken(refreshToken)
                     .build();

--- a/project/src/main/java/com/edison/project/global/config/AppConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/AppConfig.java
@@ -1,0 +1,15 @@
+package com.edison.project.global.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+@RequiredArgsConstructor
+public class AppConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -4,7 +4,7 @@ import com.edison.project.common.response.ApiResponse;
 import com.edison.project.common.status.ErrorStatus;
 import com.edison.project.domain.member.dto.MemberResponseDto;
 import com.edison.project.domain.member.service.CustomOidcUserService;
-import com.edison.project.domain.member.service.MemberServiceImpl;
+import com.edison.project.domain.member.service.MemberService;
 import com.edison.project.global.security.CustomAuthenticationEntryPoint;
 import com.edison.project.global.security.CustomUserPrincipal;
 import com.edison.project.global.security.JwtAuthenticationFilter;
@@ -38,7 +38,7 @@ import static com.edison.project.common.status.SuccessStatus._OK;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final MemberServiceImpl memberService;
+    private final MemberService memberService;
     private final CustomOidcUserService customOidcUserService;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
@@ -51,6 +51,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/.well-known/acme-challenge/**").permitAll() // 서버 인증서 관련 경로 추가
                         .requestMatchers("/members/refresh").permitAll()
+                        .requestMatchers("/members/google").permitAll()
                         .requestMatchers("/favicon.ico").permitAll()
                         .anyRequest().authenticated()
                 )


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #114 

## 📝 작업 내용

> 현재 회원가입/로그인 방식을 변경하였습니다!
-> 프론트에서 구글로그인 요청하고 발급받은 idToken을 통해 에디슨 토큰을 발급합니다!

### 📸 스크린샷 (선택)

<img width="643" alt="스크린샷 2025-02-10 오후 2 46 15" src="https://github.com/user-attachments/assets/9958d025-8c60-4d7f-9c2e-eb6ef66d0d95" />

<img width="647" alt="스크린샷 2025-02-10 오후 4 54 07" src="https://github.com/user-attachments/assets/d6d0c438-e2df-455f-8489-c9630ff4169d" />


## 💬 리뷰 요구사항(선택)

> 이제 회원가입/로그인(에디슨 서비스 토큰을 발급)을 프론트가 보내준 idToken으로 하기 때문에 환경변수인 GOOGLE_CLIENT를 프론트에서 받은 값으로 바꿔줘야 합니다! 에디슨 전체톡방에 있으니 참고해주세요! 그런데 이렇게 바꾸고 나면 웹에서 발급받은 토큰을 사용하지 못하기 때문에 환경변수 값을 바꾸지 말고 JwtUtil파일의 CLIENT_ID값을 바꿔주세요!  <img width="717" alt="스크린샷 2025-02-10 오후 3 11 26" src="https://github.com/user-attachments/assets/185fb869-9e1f-46a1-bf4e-d4ba2e9e1771" />
<img width="680" alt="스크린샷 2025-02-10 오후 3 22 18" src="https://github.com/user-attachments/assets/a4b72559-6a6d-43f0-8487-677e52a43eac" />


> 지금 테스트는 프론트에서 발급받은 idToken을 사용하여 나온 accessToken으로 다른 api가 되는지 확인해주세요!

> 정리) 프론트에서 로그인을 하려면 id토큰을 사용하여 members/google api에서 토큰 발급받아야함. 백에서는 기존 방식으로 웹에서 발급받은 access토큰을 사용하여 api테스트 할 수 있도록 해둠.

