### PR TITLE
🐛[BUG] #119 health check 컨트롤러 추가, 인증 permit

### DIFF
--- a/project/src/main/java/com/edison/project/global/HealthCheckController.java
+++ b/project/src/main/java/com/edison/project/global/HealthCheckController.java
@@ -1,0 +1,15 @@
+package com.edison.project.global;
+
+import com.edison.project.common.response.ApiResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthCheckController {
+
+    @GetMapping("/health")
+    public ResponseEntity<String> healthCheck() {
+        return ResponseEntity.ok("OK");
+    }
+}

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -49,6 +49,7 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/health").permitAll()  // Health Check 경로 인증 제외
                         .requestMatchers("/.well-known/acme-challenge/**").permitAll() // 서버 인증서 관련 경로 추가
                         .requestMatchers("/members/refresh").permitAll()
                         .requestMatchers("/members/google").permitAll()


### PR DESCRIPTION
## #⃣ 연관된 이슈

- close #119 

## 📝 작업 내용
이전 SecurityConfig.java를 보면, 모든 요청이 인증을 필요로 합니다.
/ 같은 경로를 ELB에서 헬스 체크하려 해도, Spring Security가 인증을 요구하고 있기 때문에 401 Unauthorized가 발생합니다.
ELB는 기본적으로 로그인할 수 없으므로, Health Check 엔드포인트(/health 같은 경로)에 대해 인증을 제외해야 합니다.

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
