### PR TITLE
🛠️ [REFACTOR] #124 아트레터 관련 QA

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepositoryCustomImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepositoryCustomImpl.java
@@ -17,18 +17,31 @@ public class ArtletterRepositoryCustomImpl implements ArtletterRepositoryCustom 
 
     @Override
     public Page<Artletter> searchByKeyword(String keyword, Pageable pageable) {
+        TypedQuery<Artletter> query = createSearchQuery(keyword);
+        TypedQuery<Long> countQuery = createCountQuery(keyword);
+
+        long totalRows = countQuery.getSingleResult();
+        applyPagination(query, pageable);
+
+        return new PageImpl<>(query.getResultList(), pageable, totalRows);
+    }
+
+    private TypedQuery<Artletter> createSearchQuery(String keyword) {
         String queryStr = "SELECT a FROM Artletter a WHERE a.title LIKE :keyword OR a.content LIKE :keyword";
         TypedQuery<Artletter> query = entityManager.createQuery(queryStr, Artletter.class);
         query.setParameter("keyword", "%" + keyword + "%");
+        return query;
+    }
 
+    private TypedQuery<Long> createCountQuery(String keyword) {
         String countQueryStr = "SELECT COUNT(a) FROM Artletter a WHERE a.title LIKE :keyword OR a.content LIKE :keyword";
         TypedQuery<Long> countQuery = entityManager.createQuery(countQueryStr, Long.class);
         countQuery.setParameter("keyword", "%" + keyword + "%");
-        long totalRows = countQuery.getSingleResult();
+        return countQuery;
+    }
 
+    private void applyPagination(TypedQuery<Artletter> query, Pageable pageable) {
         query.setFirstResult((int) pageable.getOffset());
         query.setMaxResults(pageable.getPageSize());
-
-        return new PageImpl<>(query.getResultList(), pageable, totalRows);
     }
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -72,12 +72,10 @@ public class ArtletterServiceImpl implements ArtletterService {
                 .build();
     }
 
+    // 아트레터 좋아요 토글 api
     @Override
     @Transactional
     public ArtletterDTO.LikeResponseDto likeToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId) {
-        if (userPrincipal == null) {
-            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
-        }
 
         Member member = memberRepository.findById(userPrincipal.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
@@ -109,37 +107,37 @@ public class ArtletterServiceImpl implements ArtletterService {
                 .build();
     }
 
+    // 아트레터 스크랩 토글 api
     @Override
+    @Transactional
     public ArtletterDTO.ScrapResponseDto scrapToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId) {
-        if (userPrincipal == null) {
-            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
-        }
 
-        Member member = memberRepository.findById(userPrincipal.getMemberId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-
-        Artletter artletter = artletterRepository.findById(letterId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.LETTERS_NOT_FOUND));
-
+        Member member = findMemberById(userPrincipal.getMemberId());
+        Artletter artletter = findArtletterById(letterId);
         boolean alreadyScrapped = scrapRepository.existsByMemberAndArtletter(member, artletter);
 
-        if (alreadyScrapped) {
-            scrapRepository.deleteByMemberAndArtletter(member, artletter);
-        } else {
-            Scrap scrap = Scrap.builder()
-                    .member(member)
-                    .artletter(artletter)
-                    .build();
-
-            scrapRepository.save(scrap);
-        }
+        toggleScrap(member, artletter, alreadyScrapped);
 
         int scrapCnt = scrapRepository.countByArtletter(artletter);
 
+        return buildScrapResponseDto(letterId, scrapCnt, !alreadyScrapped);
+    }
+
+    // 아트레터 스크랩 토글 api - 스크랩 추가/삭제 토글 메서드 분리
+    private void toggleScrap(Member member, Artletter artletter, boolean alreadyScrapped) {
+        if (alreadyScrapped) {
+            scrapRepository.deleteByMemberAndArtletter(member, artletter);
+        } else {
+            scrapRepository.save(Scrap.builder().member(member).artletter(artletter).build());
+        }
+    }
+
+    // 아트레터 스크랩 토글 api - 결과 생성 메서드 분리
+    private ArtletterDTO.ScrapResponseDto buildScrapResponseDto(Long letterId, int scrapCnt, boolean isScrapped) {
         return ArtletterDTO.ScrapResponseDto.builder()
                 .artletterId(letterId)
                 .scrapsCnt(scrapCnt)
-                .isScrapped(!alreadyScrapped)
+                .isScrapped(isScrapped)
                 .build();
     }
 
@@ -153,11 +151,8 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     public ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId) {
 
-        Member member = memberRepository.findById(userPrincipal.getMemberId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-
-        Artletter artletter = artletterRepository.findById(letterId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.LETTERS_NOT_FOUND));
+        Member member = findMemberById(userPrincipal.getMemberId());
+        Artletter artletter = findArtletterById(letterId);
 
         boolean isLiked = artletterLikesRepository.existsByMemberAndArtletter(member, artletter);
         int likesCnt = artletterLikesRepository.countByArtletter(artletter);
@@ -167,6 +162,7 @@ public class ArtletterServiceImpl implements ArtletterService {
         return buildListResponseDto(artletter, likesCnt, scrapCnt, isLiked, isScrapped);
     }
 
+    // 아트레터 상세조회 api - 결과 조회 메서드 분리
     private ArtletterDTO.ListResponseDto buildListResponseDto(Artletter artletter, int likesCnt, int scrapCnt, boolean isLiked, boolean isScrapped) {
         return ArtletterDTO.ListResponseDto.builder()
                 .artletterId(artletter.getLetterId())
@@ -389,6 +385,18 @@ public class ArtletterServiceImpl implements ArtletterService {
                 }).toList();
 
         return ApiResponse.onSuccess(SuccessStatus._OK, pageInfo, artletters);
+    }
+
+    // Member 조회 메서드 분리
+    private Member findMemberById(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    // Artletter 조회 메서드 분리
+    private Artletter findArtletterById(Long letterId) {
+        return artletterRepository.findById(letterId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.LETTERS_NOT_FOUND));
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -149,25 +149,25 @@ public class ArtletterServiceImpl implements ArtletterService {
     }
 
 
+    // 아트레터 상세조회 api
     @Override
     public ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId) {
 
-        if (userPrincipal == null) {
-            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
-        }
-
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Artletter artletter = artletterRepository.findById(letterId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LETTERS_NOT_FOUND));
-
-        Member member = memberRepository.findById(userPrincipal.getMemberId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         boolean isLiked = artletterLikesRepository.existsByMemberAndArtletter(member, artletter);
         int likesCnt = artletterLikesRepository.countByArtletter(artletter);
         boolean isScrapped = scrapRepository.existsByMemberAndArtletter(member, artletter);
         int scrapCnt = scrapRepository.countByArtletter(artletter);
 
+        return buildListResponseDto(artletter, likesCnt, scrapCnt, isLiked, isScrapped);
+    }
+
+    private ArtletterDTO.ListResponseDto buildListResponseDto(Artletter artletter, int likesCnt, int scrapCnt, boolean isLiked, boolean isScrapped) {
         return ArtletterDTO.ListResponseDto.builder()
                 .artletterId(artletter.getLetterId())
                 .title(artletter.getTitle())


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #124 

## 📝 작업 내용
전반적으로 method extracting 진행하도록, 아래 3가지 api 리팩토링 하였습니다.

**1. 아트레터 컨텐츠 페이지 조회 QA**

> - **code refactor**
> - [x] repo : 크게 search/count/pagination 로 나누어져 있었던 전체 로직을 함수로 분리함
> - [x] service : 공통적으로 쓰이는 letter, member 검증 로직을 분리 + 결과 반환함수도 분리
> - **validation logic - 수정사항 없음**


**2. 아트레터 스크랩 토글 QA**

> - **code refactor**
> - [x] service : 스크랩 토글 로직, 결과 생성 메서드를 별도 메서드로 분리함
> - **validation logic**
> - [x] 여러 사용자의 동시접근 고려하여 Transactional 설정



**3. 아트레터 좋아요 토글 QA**
> - 전체적으로 스크랩 토글과 유사하게 리팩토링



### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 코드 정상적으로 잘 돌아가는지 확인하고, 코드리뷰 부탁드려요~~
