### PR TITLE
❕ [!HOTFIX] #129 아트보드 접근, accessToken재발급 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -35,6 +35,7 @@ public class ArtletterController {
 
     // POST: 아트레터 등록
     @PostMapping
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> createArtletter(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody Map<String, Object> request) {
         // 필드 값 추출
         Object readTimeObj = request.get("readTime");
@@ -163,7 +164,6 @@ public class ArtletterController {
 
 
     @PostMapping("/editor-pick")
-    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> getEditorArtletters(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
             @RequestBody ArtletterDTO.EditorRequestDto editorRequestDto) {
@@ -191,7 +191,6 @@ public class ArtletterController {
 
 
     @GetMapping("/{letterId}")
-    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> getArtletterInfo(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
             @PathVariable("letterId") Long letterId) {

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -152,16 +152,16 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     public ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId) {
 
-        if (userPrincipal == null) {
-            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
-        }
-
-
         Artletter artletter = artletterRepository.findById(letterId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.LETTERS_NOT_FOUND));
 
-        Member member = memberRepository.findById(userPrincipal.getMemberId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        Member member;
+        if (userPrincipal != null) { //로그인한 경우에만 member 조회
+            member = memberRepository.findById(userPrincipal.getMemberId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        } else {
+            member = null;
+        }
 
         boolean isLiked = artletterLikesRepository.existsByMemberAndArtletter(member, artletter);
         int likesCnt = artletterLikesRepository.countByArtletter(artletter);
@@ -188,14 +188,18 @@ public class ArtletterServiceImpl implements ArtletterService {
 
     @Override
     public ResponseEntity<ApiResponse> getEditorArtletters(CustomUserPrincipal userPrincipal, ArtletterDTO.EditorRequestDto editorRequestDto) {
-        if (userPrincipal == null) {
-            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
-        }
+
         if (editorRequestDto == null || editorRequestDto.getArtletterIds() == null || editorRequestDto.getArtletterIds().isEmpty()) {
             throw new GeneralException(ErrorStatus.ARTLETTER_ID_REQUIRED);
         }
-        Member member = memberRepository.findById(userPrincipal.getMemberId())
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        Member member;
+        if (userPrincipal != null) { //로그인한 경우에만 member 조회
+            member = memberRepository.findById(userPrincipal.getMemberId())
+                    .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+        } else {
+            member = null;
+        }
 
         List<Long> artletterIds = editorRequestDto.getArtletterIds();
         List<Artletter> artletters = artletterRepository.findByLetterIdIn(artletterIds);

--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -37,7 +37,7 @@ public class MemberRestController {
     }
 
     @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse> refreshAccessToken(@RequestAttribute("refreshToken") String refreshToken) {
+    public ResponseEntity<ApiResponse> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
         return memberService.refreshAccessToken(refreshToken);
     }
 

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
@@ -19,6 +19,4 @@ public interface MemberService {
     MemberResponseDto.IdentityTestSaveResultDto updateIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
     ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal);
     ResponseEntity<ApiResponse> processGoogleLogin(String authorizationCode);
-    boolean existsByEmail(String email);
-    void registerNewMember(String email);
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -40,21 +40,7 @@ public class MemberServiceImpl implements MemberService{
     private final JwtUtil jwtUtil;
     private final RedisTokenService redisTokenService;
 
-    // ✅ 이메일 존재 여부 확인
-    public boolean existsByEmail(String email) {
-        return memberRepository.existsByEmail(email);
-    }
 
-    // ✅ 새 회원 등록
-    public void registerNewMember(String email) {
-        Member newMember = Member.builder()
-                .email(email)
-                .role("ROLE_USER")
-                .build();
-        memberRepository.save(newMember);
-    }
-
-    // ✅ JWT 토큰 생성
     @Override
     @Transactional
     public MemberResponseDto.LoginResultDto generateTokensForOidcUser(String email) {
@@ -134,9 +120,7 @@ public class MemberServiceImpl implements MemberService{
     @Override
     @Transactional
     public ResponseEntity<ApiResponse> updateProfile(CustomUserPrincipal userPrincipal, MemberRequestDto.UpdateProfileDto request) {
-        if (userPrincipal == null) {
-            throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
-        }
+
 
         Member member = memberRepository.findById(userPrincipal.getMemberId())
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -15,6 +15,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -49,8 +50,14 @@ public class SecurityConfig {
         http
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
+                        //로그인 없이 접근 가능
                         .requestMatchers("/.well-known/acme-challenge/**").permitAll()
                         .requestMatchers("/members/refresh", "/members/google", "/favicon.ico").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/artletters").permitAll() // 전체 아트레터 조회
+                        .requestMatchers(HttpMethod.GET, "/artletters/search").permitAll() // 검색 API
+                        .requestMatchers(HttpMethod.GET, "/artletters/{letterId}").permitAll() // 특정 아트레터 조회
+                        .requestMatchers(HttpMethod.GET, "/artletters/recommend-bar/category").permitAll() // 추천 카테고리
+                        .requestMatchers(HttpMethod.GET, "/artletters/recommend-bar/keyword").permitAll() // 추천 키워드
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -52,7 +52,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(auth -> auth
                         //로그인 없이 접근 가능
                         .requestMatchers("/.well-known/acme-challenge/**").permitAll()
-                        .requestMatchers("/members/refresh", "/members/google", "/favicon.ico").permitAll()
+                        .requestMatchers("/members/google", "/favicon.ico").permitAll()
                         .requestMatchers(HttpMethod.GET, "/artletters").permitAll() // 전체 아트레터 조회
                         .requestMatchers(HttpMethod.GET, "/artletters/search").permitAll() // 검색 API
                         .requestMatchers(HttpMethod.GET, "/artletters/{letterId}").permitAll() // 특정 아트레터 조회

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -55,9 +55,11 @@ public class SecurityConfig {
                         .requestMatchers("/members/google", "/favicon.ico").permitAll()
                         .requestMatchers(HttpMethod.GET, "/artletters").permitAll() // 전체 아트레터 조회
                         .requestMatchers(HttpMethod.GET, "/artletters/search").permitAll() // 검색 API
-                        .requestMatchers(HttpMethod.GET, "/artletters/{letterId}").permitAll() // 특정 아트레터 조회
+                        .requestMatchers(HttpMethod.GET, "/artletters/**").permitAll() //특정 아트레터 조회
                         .requestMatchers(HttpMethod.GET, "/artletters/recommend-bar/category").permitAll() // 추천 카테고리
                         .requestMatchers(HttpMethod.GET, "/artletters/recommend-bar/keyword").permitAll() // 추천 키워드
+                        .requestMatchers(HttpMethod.POST, "/artletters/editor-pick").permitAll()
+
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -85,12 +87,7 @@ public class SecurityConfig {
         OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
         String email = oidcUser.getEmail();
 
-        // ✅ 이메일 중복 체크 및 회원 등록
-        if (!memberService.existsByEmail(email)) {
-            memberService.registerNewMember(email); // 새 회원 등록
-        }
-
-        // ✅ JWT 토큰 발급
+        //JWT 토큰 발급
         MemberResponseDto.LoginResultDto dto = memberService.generateTokensForOidcUser(email);
 
         // SecurityContextHolder에 인증 정보 저장

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -147,7 +147,5 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         if (!storedRefreshToken.getRefreshToken().equals(refreshToken)) {
             throw new GeneralException(ErrorStatus.INVALID_TOKEN);
         }
-
-        request.setAttribute("refreshToken", refreshToken);
     }
 }

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -36,6 +36,31 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws IOException, ServletException {
 
         try {
+
+            String requestURI = request.getRequestURI();
+
+            // 로그인 없이 접근 가능한 경로 리스트
+            List<String> openEndpoints = List.of(
+                    "/members/refresh",
+                    "/members/google",
+                    "/favicon.ico",
+                    "/artletters",
+                    "/artletters/search",
+                    "/artletters/recommend-bar/category",
+                    "/artletters/recommend-bar/keyword"
+            );
+
+            if (requestURI.matches("^/artletters/\\d+$")) { // "/artletters/{letterId}" 패턴 허용
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // 로그인 없이 접근 가능한 경로는 필터를 통과
+            if (openEndpoints.contains(requestURI)) {
+                filterChain.doFilter(request, response);
+                return;
+            }
+
             String authHeader = request.getHeader("Authorization");
 
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -50,7 +50,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     "/artletters/editor-pick"
             );
 
-            if (method.equals("GET") && requestURI.startsWith("/artletters")) {
+            if (method.equals("GET") && requestURI.startsWith("/artletters")&& !requestURI.contains("scrap")) {
                 filterChain.doFilter(request, response);
                 return;
             }

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -41,7 +41,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             // 로그인 없이 접근 가능한 경로 리스트
             List<String> openEndpoints = List.of(
-                    "/members/refresh",
                     "/members/google",
                     "/favicon.ico",
                     "/artletters",

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -38,16 +38,22 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         try {
 
             String requestURI = request.getRequestURI();
+            String method = request.getMethod();
 
             // 로그인 없이 접근 가능한 경로 리스트
             List<String> openEndpoints = List.of(
                     "/members/google",
                     "/favicon.ico",
-                    "/artletters",
                     "/artletters/search",
                     "/artletters/recommend-bar/category",
-                    "/artletters/recommend-bar/keyword"
+                    "/artletters/recommend-bar/keyword",
+                    "/artletters/editor-pick"
             );
+
+            if (method.equals("GET") && requestURI.startsWith("/artletters")) {
+                filterChain.doFilter(request, response);
+                return;
+            }
 
             if (requestURI.matches("^/artletters/\\d+$")) { // "/artletters/{letterId}" 패턴 허용
                 filterChain.doFilter(request, response);


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #129 

## 📝 작업 내용

> 아트레터 등록, 스크랩/좋아요, 스크랩 아트레터 조회 api를 제외한 아트보트api들은 로그인 없이 접근 가능하게 수정했습니다!
> accessToken 재발급이 안 되는 문제도 수정했습니다!(members/refresh api)

### 📸 스크린샷 (선택)
<img width="645" alt="스크린샷 2025-02-13 오전 9 59 24" src="https://github.com/user-attachments/assets/2b70b650-9667-4669-b8e4-1721d6104a94" />
<img width="643" alt="스크린샷 2025-02-13 오전 10 00 00" src="https://github.com/user-attachments/assets/dd90d617-6436-4d69-9019-191f3b75fb5a" />

<img width="650" alt="스크린샷 2025-02-13 오전 10 15 32" src="https://github.com/user-attachments/assets/97b26364-0a64-4400-9e8b-7911c7cc0173" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 아트보드 api요청이 되는지 확인해주세용
>토큰 재발급도 확인해주시면 감사하겠습니당
