### PR TITLE
❕ [!HOTFIX] #139 회원가입/로그인 응답dto 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
 public class MemberResponseDto {
 
@@ -17,6 +18,7 @@ public class MemberResponseDto {
     @AllArgsConstructor
     public static class LoginResultDto{
 
+        private AtomicReference<Boolean> isNewMember;
         private Long memberId;
         private String email;
         private String accessToken;

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -25,6 +25,7 @@ import org.springframework.transaction.annotation.Transactional;
 import com.edison.project.domain.member.entity.Member;
 
 import java.util.*;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static com.edison.project.common.status.SuccessStatus._OK;
@@ -44,8 +45,11 @@ public class MemberServiceImpl implements MemberService{
     @Override
     @Transactional
     public MemberResponseDto.LoginResultDto generateTokensForOidcUser(String email) {
+
+        AtomicReference<Boolean> isNew = new AtomicReference<>(false);
         Member member = memberRepository.findByEmail(email)
                 .orElseGet(() -> {
+                    isNew.set(true);
                     Member newMember = Member.builder()
                             .email(email)
                             .role("ROLE_USER")
@@ -61,6 +65,7 @@ public class MemberServiceImpl implements MemberService{
         refreshTokenRepository.save(tokenEntity);
 
         return MemberResponseDto.LoginResultDto.builder()
+                .isNewMember(isNew)
                 .memberId(member.getMemberId())
                 .email(member.getEmail())
                 .accessToken(accessToken)


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #139 

## 📝 작업 내용

> 회원가입/로그인 응답dto 수정하였습니다!
> isNewUser: true (회원가입), false (로그인)

### 📸 스크린샷 (선택)
<img width="1060" alt="스크린샷 2025-02-16 오후 11 15 32" src="https://github.com/user-attachments/assets/2c2ca10b-a816-4135-883f-db378b588a52" />
<img width="1067" alt="스크린샷 2025-02-16 오후 11 16 21" src="https://github.com/user-attachments/assets/01bfddc4-5f4e-4e10-819d-8a09c9e64e6d" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
