### PR TITLE
🛠️ [REFACTOR] #141 개인정보 관련 QA

### DIFF
--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -30,7 +30,7 @@ public enum ErrorStatus {
 
     // 멤버 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
-    NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수 입니다."),
+    INVALID_NICKNAME(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 공백일 수 없습니다."),
     NICKNAME_NOT_CHANGED(HttpStatus.BAD_REQUEST, "MEMBER4003", "닉네임이 변경되지 않았습니다."),
     PROFILE_NOT_CHANGED(HttpStatus.BAD_REQUEST, "MEMBER4004", "프로필이 변경되지 않았습니다."),
     NICKNAME_ALREADY_SET(HttpStatus.BAD_REQUEST, "MEMBER4005", "닉네임은 최초 1회만 설정 가능합니다."),

--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -22,22 +22,24 @@ public class MemberRestController {
 
     // 회원정보(닉네임) 설정
     @PostMapping("/register")
-    public ResponseEntity<ApiResponse> registerMember(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.CreateProfileDto request) {
-        return memberService.registerMember(userPrincipal, request);
+    public ResponseEntity<ApiResponse> createProfile(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.CreateProfileDto request) {
+        return memberService.createProfile(userPrincipal, request);
     }
 
     // 회원정보 변경
     @PatchMapping("/profile")
-    public ResponseEntity<ApiResponse> updateProfile(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.UpdateProfileDto request) {
+    public ResponseEntity<ApiResponse> updateProfile(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.UpdateProfileDto request) {
         return memberService.updateProfile(userPrincipal, request);
     }
 
     // 회원정보 조회
     @GetMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse> getMember(
+    public ResponseEntity<ApiResponse> getProfile(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        return memberService.getMember(userPrincipal);
+        return memberService.getProfile(userPrincipal);
     }
 
 

--- a/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
+++ b/project/src/main/java/com/edison/project/domain/member/controller/MemberRestController.java
@@ -20,26 +20,27 @@ public class MemberRestController {
 
     private final MemberService memberService;
 
+    // 회원정보(닉네임) 설정
     @PostMapping("/register")
-    public ResponseEntity<ApiResponse> registerMember(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.ProfileDto request) {
+    public ResponseEntity<ApiResponse> registerMember(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.CreateProfileDto request) {
         return memberService.registerMember(userPrincipal, request);
     }
 
+    // 회원정보 변경
     @PatchMapping("/profile")
     public ResponseEntity<ApiResponse> updateProfile(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, @RequestBody MemberRequestDto.UpdateProfileDto request) {
         return memberService.updateProfile(userPrincipal, request);
     }
 
-    @PostMapping("/logout")
+    // 회원정보 조회
+    @GetMapping
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse> logout(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        return memberService.logout(userPrincipal);
+    public ResponseEntity<ApiResponse> getMember(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        return memberService.getMember(userPrincipal);
     }
 
-    @PostMapping("/refresh")
-    public ResponseEntity<ApiResponse> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
-        return memberService.refreshAccessToken(refreshToken);
-    }
+
 
     @PostMapping("/identity")
     @PreAuthorize("isAuthenticated()")
@@ -57,12 +58,6 @@ public class MemberRestController {
         return ApiResponse.onSuccess(SuccessStatus._OK, result);
     }
 
-    @DeleteMapping("/cancel")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse> cancel(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        return memberService.cancel(userPrincipal);
-    }
-
     @PatchMapping("/identity")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> updateIdentityTest(
@@ -72,11 +67,23 @@ public class MemberRestController {
         return ApiResponse.onSuccess(SuccessStatus._OK, result);
     }
 
-    @GetMapping
+
+
+    @PostMapping("/logout")
     @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse> getMember(
-            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        return memberService.getMember(userPrincipal);
+    public ResponseEntity<ApiResponse> logout(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        return memberService.logout(userPrincipal);
+    }
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ApiResponse> refreshAccessToken(@RequestHeader("Refresh-Token") String refreshToken) {
+        return memberService.refreshAccessToken(refreshToken);
+    }
+
+    @DeleteMapping("/cancel")
+    @PreAuthorize("isAuthenticated()")
+    public ResponseEntity<ApiResponse> cancel(@AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        return memberService.cancel(userPrincipal);
     }
 
     @PostMapping("/google")

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
@@ -14,7 +14,7 @@ public class MemberRequestDto {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ProfileDto {
+    public static class CreateProfileDto {
 
         @NotBlank(message = "닉네임은 필수입니다.")
         @Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
@@ -32,9 +32,8 @@ public class MemberRequestDto {
         private String nickname;
 
         private String imageUrl;
-
     }
-  
+
     @Builder
     @Getter
     @NoArgsConstructor
@@ -47,7 +46,6 @@ public class MemberRequestDto {
         @NotEmpty(message = "키워드는 최소 하나 이상 선택해야 합니다.")
         @Size(max = 5, message = "키워드는 최대 5개까지 선택할 수 있습니다.")
         private List<Integer> keywords;
-
     }
 
     @Builder
@@ -57,6 +55,4 @@ public class MemberRequestDto {
     public static class GoogleLoginDto{
         private String idToken;
     }
-
-
 }

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberRequestDto.java
@@ -16,8 +16,7 @@ public class MemberRequestDto {
     @AllArgsConstructor
     public static class CreateProfileDto {
 
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
+        @NotBlank
         private String nickname;
     }
 
@@ -27,8 +26,7 @@ public class MemberRequestDto {
     @AllArgsConstructor
     public static class UpdateProfileDto {
 
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(max = 20, message = "닉네임은 최대 20자까지 가능합니다.")
+        @NotBlank
         private String nickname;
 
         private String imageUrl;

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
@@ -26,10 +26,7 @@ public class MemberResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class UpdateProfileResultDto {
-
-        @NotBlank(message = "닉네임은 필수입니다.")
         private String nickname;
-
         private String imageUrl;
     }
 
@@ -38,12 +35,8 @@ public class MemberResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ProfileResultDto {
-
         private String email;
-
-        @NotBlank(message = "닉네임은 필수입니다.")
         private String nickname;
-
         private String profileImg;
     }
 

--- a/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/member/dto/MemberResponseDto.java
@@ -12,24 +12,12 @@ import java.util.concurrent.atomic.AtomicReference;
 
 public class MemberResponseDto {
 
+    // 개인정보 관련 DTO
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class LoginResultDto{
-
-        private AtomicReference<Boolean> isNewMember;
-        private Long memberId;
-        private String email;
-        private String accessToken;
-        private String refreshToken;
-    }
-
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class ProfileResultDto{
+    public static class CreateProfileResultDto {
         private String nickname;
     }
 
@@ -44,15 +32,24 @@ public class MemberResponseDto {
 
         private String imageUrl;
     }
-  
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class RefreshResultDto{
-        private String accessToken;
+    public static class ProfileResultDto {
+
+        private String email;
+
+        @NotBlank(message = "닉네임은 필수입니다.")
+        private String nickname;
+
+        private String profileImg;
     }
 
+
+
+    // 아이덴티티 관련 DTO
     @Builder
     @Getter
     @NoArgsConstructor
@@ -79,17 +76,28 @@ public class MemberResponseDto {
         private Map<String, List<IdentityKeywordDto>> categories;
     }
 
+
+
+    // 로그인 관련 DTO
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemberResultDto {
-
-        private String email;
-
-        @NotBlank(message = "닉네임은 필수입니다.")
-        private String nickname;
-
-        private String profileImg;
+    public static class RefreshResultDto{
+        private String accessToken;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class LoginResultDto{
+
+        private AtomicReference<Boolean> isNewMember;
+        private Long memberId;
+        private String email;
+        private String accessToken;
+        private String refreshToken;
+    }
+
 }

--- a/project/src/main/java/com/edison/project/domain/member/entity/Member.java
+++ b/project/src/main/java/com/edison/project/domain/member/entity/Member.java
@@ -53,27 +53,4 @@ public class Member extends BaseEntity {
         super();
     }
 
-    //복사 빌더 메서드
-    public Member registerProfile(String nickname) {
-        return Member.builder()
-                .memberId(this.memberId)
-                .email(this.email)
-                .nickname(nickname)
-                .profileImg(this.profileImg)
-                .isDeleted(this.isDeleted)
-                .bubbles(new ArrayList<>(this.bubbles))
-                .labels(new ArrayList<>(this.labels))
-                .build();
-    }
-
-    @Transactional
-    public void updateProfile(String nickname, String profileImg) {
-        this.nickname = nickname;
-        this.profileImg = profileImg;
-    }
-
-    @Transactional
-    public void updateNickname(String nickname) {
-        this.nickname = nickname;
-    }
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
@@ -7,16 +7,18 @@ import com.edison.project.global.security.CustomUserPrincipal;
 import org.springframework.http.ResponseEntity;
 
 public interface MemberService {
-    MemberResponseDto.LoginResultDto generateTokensForOidcUser(String email);
-    Long createUserIfNotExist(String email);
-    ResponseEntity<ApiResponse> registerMember(CustomUserPrincipal userPrincipal, MemberRequestDto.ProfileDto request);
+    ResponseEntity<ApiResponse> registerMember(CustomUserPrincipal userPrincipal, MemberRequestDto.CreateProfileDto request);
     ResponseEntity<ApiResponse> updateProfile(CustomUserPrincipal userPrincipal, MemberRequestDto.UpdateProfileDto request);
-    ResponseEntity<ApiResponse> logout(CustomUserPrincipal userPrincipal);
-    ResponseEntity<ApiResponse> refreshAccessToken(String token);
+    ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal);
+
     MemberResponseDto.IdentityTestSaveResultDto saveIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
     MemberResponseDto.IdentityKeywordsResultDto getIdentityKeywords(CustomUserPrincipal userPrincipal);
-    ResponseEntity<ApiResponse> cancel(CustomUserPrincipal userPrincipal);
     MemberResponseDto.IdentityTestSaveResultDto updateIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
-    ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal);
+
+    MemberResponseDto.LoginResultDto generateTokensForOidcUser(String email);
+    Long createUserIfNotExist(String email);
+    ResponseEntity<ApiResponse> logout(CustomUserPrincipal userPrincipal);
+    ResponseEntity<ApiResponse> refreshAccessToken(String token);
+    ResponseEntity<ApiResponse> cancel(CustomUserPrincipal userPrincipal);
     ResponseEntity<ApiResponse> processGoogleLogin(String authorizationCode);
 }

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberService.java
@@ -7,9 +7,9 @@ import com.edison.project.global.security.CustomUserPrincipal;
 import org.springframework.http.ResponseEntity;
 
 public interface MemberService {
-    ResponseEntity<ApiResponse> registerMember(CustomUserPrincipal userPrincipal, MemberRequestDto.CreateProfileDto request);
+    ResponseEntity<ApiResponse> createProfile(CustomUserPrincipal userPrincipal, MemberRequestDto.CreateProfileDto request);
     ResponseEntity<ApiResponse> updateProfile(CustomUserPrincipal userPrincipal, MemberRequestDto.UpdateProfileDto request);
-    ResponseEntity<ApiResponse> getMember(CustomUserPrincipal userPrincipal);
+    ResponseEntity<ApiResponse> getProfile(CustomUserPrincipal userPrincipal);
 
     MemberResponseDto.IdentityTestSaveResultDto saveIdentityTest(CustomUserPrincipal userPrincipal, MemberRequestDto.IdentityTestSaveDto request);
     MemberResponseDto.IdentityKeywordsResultDto getIdentityKeywords(CustomUserPrincipal userPrincipal);

--- a/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/member/service/MemberServiceImpl.java
@@ -81,6 +81,19 @@ public class MemberServiceImpl implements MemberService{
 
     }
 
+    // 개인정보 변경 API - 이미지 여부에 따른 빌드 로직 분리
+    private MemberResponseDto.UpdateProfileResultDto updateNicknameOrProfile(Member member, String nickname, String imageUrl) {
+        if (imageUrl == null) {
+            member.updateNickname(nickname);
+        } else {
+            member.updateProfile(nickname, imageUrl);
+        }
+        return MemberResponseDto.UpdateProfileResultDto.builder()
+                .nickname(member.getNickname())
+                .imageUrl(member.getProfileImg())
+                .build();
+    }
+
 
 
     // 개인정보 조회 API


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #141 

## 📝 작업 내용

> 개인정보 관련 3개 api QA 진행하였습니다.
> 1. 개인정보(닉네임) 설정
> 2. 개인정보 변경
> 3. 개인정보 조회


- code refactor
    - [x]  설정/변경/조회가 잘 구별되도록 메소드들 rename (DTO, 컨트롤러, 서비스 단)
    - [x]  error status도 의도를 잘 드러내도록 rename
    - [x]  `멤버 검증`, `닉네임 검증` 로직들 → 공통 메서드로 분리
- logic
    - [x]  중복 검증 로직 제거 (동일한 유효검사를 컨트&서비스 단에서 2번 하고 있었음)
    - [x]  requestdto단의 불필요한 `@Valid` 검증 제거
    - [x]  **[변경 API] : 닉네임을 20자 이상으로 수정 가능한 에러 해결**


### 📸 스크린샷 (선택)

<img width="559" alt="image" src="https://github.com/user-attachments/assets/b1c7c390-34d8-483d-bb28-3b679b56c6f0" />

## 💬 리뷰 요구사항(선택)

> 기능변화 없는 코드 리팩터링 & 불필요한 검증 로직 제거 위주로 QA 해서 크게 바뀐 건 없습니다
>
> 기존의 2.개인정보 변경 api 에서는, 
닉네임을 20자 이상으로 수정 가능했어서 요거 고쳤는데 
이부분만 테스트 해주세요!
