### PR TITLE
❕[!HOTFIX] #143: 라벨 local_idx 관련 로직 전면 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -22,7 +22,7 @@ public class BubbleRequestDto {
         private String title;
         private String content;
         private String mainImageUrl;
-        private Set<Long> labelIds;  // 중복 방지
+        private Set<Long> labelIdxSet;  // 중복 방지
     }
 
     @Getter
@@ -52,7 +52,7 @@ public class BubbleRequestDto {
         private String title;
         private String content;
         private String mainImageUrl;
-        private Set<Long> labelIds;
+        private Set<Long> labelIdxs;
         private Set<Long> backlinkIds;
 
         @NotNull(message = "(DTO)삭제 여부는 필수입니다.")

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -51,7 +51,7 @@ public class Bubble {
     @Column(name = "deleted_at", nullable = true)
     protected LocalDateTime deletedAt;
 
-    @OneToMany(mappedBy = "bubble", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
+    @OneToMany(mappedBy = "bubble", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
     private Set<BubbleLabel> labels = new HashSet<>();
 
     @OneToMany(mappedBy = "bubble", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -441,25 +441,13 @@ public class BubbleServiceImpl implements BubbleService {
         Set<Long> idxs = Optional.ofNullable(labelIdxs).orElse(Collections.emptySet());
 
         if (idxs.isEmpty()) {
-            System.out.println("🔴 LabelIdxs가 비어 있음");
             return Collections.emptySet(); // 빈 Set 반환
         }
-
         if (idxs.size() > 3) {
             throw new GeneralException(ErrorStatus.LABELS_TOO_MANY);
         }
 
-        System.out.println("🟢 찾으려는 labelIdxs: " + idxs);
-        System.out.println("🟢 찾으려는 member: " + member.getMemberId());
-
         Set<Label> labels = new HashSet<>(labelRepository.findAllByMemberAndLocalIdxIn(member, idxs));
-
-        if (labels.isEmpty()) {
-            System.out.println("🔴 반환된 Label이 없음");
-        } else {
-            System.out.println("🟢 반환된 Labels: " + labels);
-        }
-
         // 조회된 라벨의 localIdx와 요청된 localIdx가 일치하는지 확인
         Set<Long> foundIdxs = labels.stream().map(Label::getLocalIdx).collect(Collectors.toSet());
         if (!foundIdxs.containsAll(idxs)) {

--- a/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
+++ b/project/src/main/java/com/edison/project/domain/label/controller/LabelRestController.java
@@ -33,12 +33,12 @@ public class LabelRestController {
         return ApiResponse.onSuccess(SuccessStatus._OK, labels);
     }
 
-    @GetMapping("/{labelId}")
+    @GetMapping("/{localIdx}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> getLabelDetail(
-            @PathVariable Long labelId,
+            @PathVariable Long localIdx,
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
-        LabelResponseDTO.DetailResultDto details = labelQueryService.getLabelDetailInfoList(userPrincipal, labelId);
+        LabelResponseDTO.DetailResultDto details = labelQueryService.getLabelDetailInfoList(userPrincipal, localIdx);
         return ApiResponse.onSuccess(SuccessStatus._OK, details);
     }
 

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelRequestDTO.java
@@ -14,7 +14,7 @@ public class LabelRequestDTO {
     public static class LabelSyncRequestDTO {
 
         @NotNull(message = "(DTO)라벨 ID는 필수입니다.")
-        private Long labelId;
+        private Long localIdx;
 
         @NotBlank(message = "(DTO)라벨 이름은 필수입니다.")
         private String name;

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -13,7 +13,7 @@ public class LabelResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LabelSimpleInfoDto {
-        private Long labelId;
+        private Long localIdx;
         private String name;
         private int color;
     }

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -46,7 +46,7 @@ public class LabelResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class LabelSyncResponseDTO {
-        private Long labelId;
+        private Long localIdx;
         private String name;
         private int color;
         private Boolean isDeleted;

--- a/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
+++ b/project/src/main/java/com/edison/project/domain/label/dto/LabelResponseDTO.java
@@ -23,7 +23,7 @@ public class LabelResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ListResultDto {
-        private Long labelId;
+        private Long localIdx;
         private String name;
         private int color;
         private Long bubbleCount;
@@ -34,7 +34,7 @@ public class LabelResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class DetailResultDto {
-        private Long labelId;
+        private Long localIdx;
         private String name;
         private int color;
         private Long bubbleCount;

--- a/project/src/main/java/com/edison/project/domain/label/entity/Label.java
+++ b/project/src/main/java/com/edison/project/domain/label/entity/Label.java
@@ -18,9 +18,12 @@ import java.util.*;
 public class Label {
 
     @Id
-    //@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "label_id")
     private Long labelId;
+
+    @Column(name="local_idx")
+    private Long localIdx;
 
     @Column(name = "name")
     private String name;
@@ -48,7 +51,7 @@ public class Label {
     // 생성자 및 빌더 추가
     @Builder
     public Label(Long labelId, String name, int color, Member member, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
-        this.labelId = labelId;
+        this.localIdx = labelId;
         this.name = name;
         this.color = color;
         this.member = member;

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -1,11 +1,13 @@
 package com.edison.project.domain.label.repository;
 
 import com.edison.project.domain.label.entity.Label;
+import com.edison.project.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface LabelRepository extends JpaRepository<Label, Long> {
 
@@ -17,7 +19,10 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
             "GROUP BY l")
     List<Object[]> findLabelInfoByMemberId(@Param("memberId") Long memberId);
 
-    // 사용자 id와 local_idx로 버블 조회
+
+    Optional<Label> findLabelByMemberAndLocalIdx(Member member, Long localIdx);
+
+    boolean existsByMemberAndLocalIdx(Member member, Long localIdx);
 
     boolean existsByLabelId(Long labelId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public interface LabelRepository extends JpaRepository<Label, Long> {
 
@@ -19,6 +20,7 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
             "GROUP BY l")
     List<Object[]> findLabelInfoByMemberId(@Param("memberId") Long memberId);
 
+    Set<Label> findAllByMemberAndLocalIdxIn(Member member, Set<Long> localIdxs);
 
     Optional<Label> findLabelByMemberAndLocalIdx(Member member, Long localIdx);
 

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -23,6 +23,4 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
     Optional<Label> findLabelByMemberAndLocalIdx(Member member, Long localIdx);
 
     boolean existsByMemberAndLocalIdx(Member member, Long localIdx);
-
-    boolean existsByLabelId(Long labelId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
+++ b/project/src/main/java/com/edison/project/domain/label/repository/LabelRepository.java
@@ -17,5 +17,7 @@ public interface LabelRepository extends JpaRepository<Label, Long> {
             "GROUP BY l")
     List<Object[]> findLabelInfoByMemberId(@Param("memberId") Long memberId);
 
+    // 사용자 id와 local_idx로 버블 조회
+
     boolean existsByLabelId(Long labelId);
 }

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -38,18 +38,17 @@ public class LabelQueryServiceImpl implements LabelQueryService {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
-        if (!memberRepository.existsById(userPrincipal.getMemberId())) {
-            throw new GeneralException(ErrorStatus.MEMBER_NOT_FOUND);
-        }
+        Member member = memberRepository.findById(userPrincipal.getMemberId())
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        List<Object[]> labelInfoList = labelRepository.findLabelInfoByMemberId(userPrincipal.getMemberId());
+        List<Object[]> labelInfoList = labelRepository.findLabelInfoByMemberId(member.getMemberId());
 
         return labelInfoList.stream()
                 .map(result -> {
                     Label label = (Label) result[0];
                     Long bubbleCount = (Long) result[1];
                     return LabelResponseDTO.ListResultDto.builder()
-                            .labelId(label.getLabelId())
+                            .localIdx(label.getLocalIdx())
                             .name(label.getName())
                             .color(label.getColor())
                             .bubbleCount(bubbleCount != null ? bubbleCount : 0L) // 버블 없는 라벨은 0으로 처리
@@ -61,7 +60,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
     // 라벨 상세 조회
     @Override
-    public LabelResponseDTO.DetailResultDto getLabelDetailInfoList(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, Long labelId) {
+    public LabelResponseDTO.DetailResultDto getLabelDetailInfoList(@AuthenticationPrincipal CustomUserPrincipal userPrincipal, Long localIdx) {
         if (userPrincipal == null) {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
@@ -83,7 +82,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
         // BubbleDetailDto 변환
         return LabelResponseDTO.DetailResultDto.builder()
-                .labelId(label.getLabelId())
+                .localIdx(label.getLabelId())
                 .name(label.getName())
                 .color(label.getColor())
                 .bubbleCount((long) bubbleDetails.size())

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -91,7 +91,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
     private BubbleResponseDto.SyncResultDto convertToBubbleResponseDto(Bubble bubble) {
         List<LabelResponseDTO.LabelSimpleInfoDto> labelDtos = bubble.getLabels().stream()
                 .map(bl -> LabelResponseDTO.LabelSimpleInfoDto.builder()
-                        .labelId(bl.getLabel().getLabelId())
+                        .localIdx(bl.getLabel().getLocalIdx())
                         .name(bl.getLabel().getName())
                         .color(bl.getLabel().getColor())
                         .build())

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -161,7 +161,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
         label.setUpdatedAt(request.getUpdatedAt());
 
         labelRepository.save(label);
-        return buildLabelResponse(label.getLabelId(), label.getName(), label.getColor(), false, label.getCreatedAt(), label.getUpdatedAt(), label.getDeletedAt());
+        return buildLabelResponse(label.getLocalIdx(), label.getName(), label.getColor(), false, label.getCreatedAt(), label.getUpdatedAt(), label.getDeletedAt());
     }
 
     // 라벨 생성 처리
@@ -170,7 +170,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
                 .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
         Label label = Label.builder()
-                .labelId(request.getLabelId())
+                .localIdx(request.getLabelId())
                 .name(request.getName())
                 .color(request.getColor())
                 .member(member)
@@ -181,12 +181,12 @@ public class LabelQueryServiceImpl implements LabelQueryService {
 
         labelRepository.save(label);
 
-        return buildLabelResponse(label.getLabelId(), label.getName(), label.getColor(), false, label.getCreatedAt(), label.getUpdatedAt(), label.getDeletedAt());
+        return buildLabelResponse(label.getLocalIdx(), label.getName(), label.getColor(), false, label.getCreatedAt(), label.getUpdatedAt(), label.getDeletedAt());
     }
 
-    private LabelResponseDTO.LabelSyncResponseDTO buildLabelResponse(Long labelId,String name, int color, boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
+    private LabelResponseDTO.LabelSyncResponseDTO buildLabelResponse(Long localIdx, String name, int color, boolean isDeleted, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
         return LabelResponseDTO.LabelSyncResponseDTO.builder()
-                .labelId(labelId)
+                .localIdx(localIdx)
                 .name(name)
                 .color(color)
                 .isDeleted(isDeleted)


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #143 

## 📝 작업 내용
전체 아트레터 조회 QA, 아트레터 검색 QA, 아트레터 정렬 추가구현 진행함.

**라벨**
> - logic
>     - SYNC, 조회 등 모든 API에서 서버 DB의 id 값이 아닌 서버 DB의 local_idx 값(즉 사용자 로컬 DB의 pk 값)을 사용하도록 수정
>     - 라벨을 조회할 때 member와 local_idx 값으로 찾으므로 권한 검증 로직 삭제



**버블**
> - logic
>     - 라벨과 동일하게 request로는 localIdx를 받아옴
>     - 내부 로직에서는 localIdx -> label Id 값으로 변환하여 수행
>     - response에는 다시 localIdx 로 변환한 리스트로 반환

수정된 API
- 라벨 SYNC
- 라벨 목록 조회
- 라벨 상세 조회
- 버블 SYNC
- 버블 검색
- 버블 리스트 조회 (전체, 7일 이내, 상세정보)

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 수정된 API 가 모두 잘 돌아가는 지, localIdx값으로 잘 작동하고 저장되는 지 확인해주세요
