### PR TITLE
❕[!HOTFIX] #146: 버블 local_idx 관련 로직 전면 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -48,7 +48,7 @@ public class BubbleRestController {
         @RequestParam(defaultValue = "0") int page,
         @RequestParam(defaultValue = "20") int size) {
 
-        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.ASC, "deletedAt"));
         return bubbleService.getDeletedBubbles(userPrincipal, pageable);
     }
 

--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -77,26 +77,6 @@ public class BubbleRestController {
 
     }
 
-    // 버블 검색
-    @GetMapping("/search")
-    @PreAuthorize("isAuthenticated()")
-    public ResponseEntity<ApiResponse> searchBubbles(
-            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
-            @RequestParam String keyword,
-            @RequestParam(defaultValue = "false") boolean recent,
-            @RequestParam(defaultValue = "0") int page,
-            @RequestParam(defaultValue = "20") int size) {
-
-        if (keyword == null || keyword.trim().isEmpty()) {
-            throw new GeneralException(ErrorStatus.INVALID_KEYWORD);
-        }
-
-        keyword = keyword.trim();
-
-        Pageable pageable = PageRequest.of(page, size);
-        return bubbleService.searchBubbles(userPrincipal, keyword, recent, pageable);
-    }
-
     // 버블 SYNC
     @PostMapping("/sync")
     @PreAuthorize("isAuthenticated()")

--- a/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/controller/BubbleRestController.java
@@ -54,12 +54,12 @@ public class BubbleRestController {
 
 
     // 버블 상세정보 조회
-    @GetMapping("/{bubbleId}")
+    @GetMapping("/{localIdx}")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> getBubble (
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
-            @PathVariable Long bubbleId) {
-        BubbleResponseDto.SyncResultDto response = bubbleService.getBubble(userPrincipal, bubbleId);
+            @PathVariable Long localIdx) {
+        BubbleResponseDto.SyncResultDto response = bubbleService.getBubble(userPrincipal, localIdx);
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -18,33 +18,6 @@ public class BubbleRequestDto {
     @Setter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class ListDto {
-        private String title;
-        private String content;
-        private String mainImageUrl;
-        private Set<Long> labelIdxSet;  // 중복 방지
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class DeleteDto {
-        private Long bubbleId;
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RestoreDto {
-        private Long bubbleId;
-    }
-
-    @Getter
-    @Setter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class SyncDto {
         @NotNull(message = "(DTO)버블 ID는 필수입니다.")
         private Long BubbleId;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleRequestDto.java
@@ -20,7 +20,7 @@ public class BubbleRequestDto {
     @AllArgsConstructor
     public static class SyncDto {
         @NotNull(message = "(DTO)버블 ID는 필수입니다.")
-        private Long BubbleId;
+        private Long localIdx;
 
         private String title;
         private String content;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -14,7 +14,7 @@ public class BubbleResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class TrashedListResultDto {
-        private Long bubbleId;
+        private Long localIdx;
         private String title;
         private String content;
         private String mainImageUrl;
@@ -30,7 +30,7 @@ public class BubbleResponseDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class SyncResultDto {
-        private Long bubbleId;
+        private Long localIdx;
         private String title;
         private String content;
         private String mainImageUrl;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -13,24 +13,6 @@ public class BubbleResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class TrashResultDto {
-        private Long bubbleId;
-        private boolean isTrashed;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class RestoreResultDto {
-        private Long bubbleId;
-        private boolean isRestored;
-    }
-
-    @Getter
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class TrashedListResultDto {
         private Long bubbleId;
         private String title;

--- a/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/dto/BubbleResponseDto.java
@@ -19,9 +19,10 @@ public class BubbleResponseDto {
         private String content;
         private String mainImageUrl;
         private List<LabelResponseDTO.LabelSimpleInfoDto> labels;
-        private Set<Long> backlinkIds;
+        private Set<Long> backlinkIdxs;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
+        private LocalDateTime deletedAt;
         private Integer remainDay;
     }
 
@@ -35,7 +36,7 @@ public class BubbleResponseDto {
         private String content;
         private String mainImageUrl;
         private List<LabelResponseDTO.LabelSimpleInfoDto> labels;
-        private Set<Long> backlinkIds;
+        private Set<Long> backlinkIdxs;
         private Boolean isDeleted;
         private Boolean isTrashed;
         private LocalDateTime createdAt;

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -14,8 +14,7 @@ import java.util.Set;
 @Setter
 @Table(name = "Bubble", indexes = {
         @Index(name = "idx_bubble_member_id", columnList = "member_id"),
-        @Index(name = "idx_bubble_title", columnList = "title")})
-
+        @Index(name = "idx_localIdx", columnList = "local_idx")})
 public class Bubble {
 
     @Id
@@ -64,9 +63,9 @@ public class Bubble {
     private Set<BubbleBacklink> referencingBubbles = new HashSet<>();
 
     @Builder
-    public Bubble(Member member, Long bubbleId, String title, String content, String mainImg, Set<BubbleLabel> labels,
+    public Bubble(Member member, Long localIdx, String title, String content, String mainImg, Set<BubbleLabel> labels,
                   boolean isTrashed, LocalDateTime createdAt, LocalDateTime updatedAt, LocalDateTime deletedAt) {
-        this.bubbleId = bubbleId;
+        this.localIdx = localIdx;
         this.member = member;
         this.title = title;
         this.content = content;

--- a/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/entity/Bubble.java
@@ -19,9 +19,12 @@ import java.util.Set;
 public class Bubble {
 
     @Id
-    // @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bubble_id")
     private Long bubbleId;
+
+    @Column(name = "local_idx")
+    private Long localIdx;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)
@@ -36,7 +39,7 @@ public class Bubble {
     @Column(name = "main_img", length = 2083)
     private String mainImg;
 
-    @Column(name = "is_deleted", nullable = false)  //휴지통에도 없는!
+    @Column(name = "is_deleted", nullable = false)  //휴지통에도 없는
     private boolean isDeleted = false;
 
     @Column(name = "is_trashed", nullable = false)  //휴지통에 있는 지(soft_delete)
@@ -48,7 +51,7 @@ public class Bubble {
     @Column(name = "updated_at", nullable = false)
     protected LocalDateTime updatedAt;
 
-    @Column(name = "deleted_at", nullable = true)
+    @Column(name = "deleted_at", nullable = true)  // 휴지통에 들어간 시간
     protected LocalDateTime deletedAt;
 
     @OneToMany(mappedBy = "bubble", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
@@ -87,16 +90,9 @@ public class Bubble {
         this.labels.addAll(bubbleLabels);
     }
 
-    public void setLabels(Set<BubbleLabel> labels) {
-        this.labels = labels;
-    }
 
     public void setTrashed (boolean trashed) {
         this.isTrashed = trashed;
-    }
-
-    public boolean isTrashed() {
-        return isTrashed;
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -1,6 +1,8 @@
 package com.edison.project.domain.bubble.repository;
 
 import com.edison.project.domain.bubble.entity.Bubble;
+import com.edison.project.domain.label.entity.Label;
+import com.edison.project.domain.member.entity.Member;
 import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -13,15 +15,13 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 @Repository
 public interface BubbleRepository extends JpaRepository<Bubble, Long> {
 
     // 삭제되지 않은 Bubble만 조회
     Optional<Bubble> findByBubbleIdAndIsTrashedFalse(Long bubbleId);
-
-    // 휴지통에 있는 Bubble만 조회
-    Optional<Bubble> findByBubbleIdAndIsTrashedTrue(Long bubbleId);
 
     Page<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId, Pageable pageable);
     Page<Bubble> findByMember_MemberIdAndIsTrashedTrue(Long memberId, Pageable pageable);
@@ -34,15 +34,12 @@ public interface BubbleRepository extends JpaRepository<Bubble, Long> {
             Pageable pageable
     );
 
-    // 전체 버블 검색
-    @Query("SELECT b FROM Bubble b " +
-            "WHERE (b.title LIKE %:keyword% OR b.content LIKE %:keyword% " +
-            "OR EXISTS (SELECT 1 FROM BubbleLabel bl WHERE bl.bubble = b AND bl.label.name LIKE %:keyword%)) " +
-            "AND b.isTrashed = false")
-    List<Bubble> searchBubblesByKeyword(@Param("keyword") String keyword);
-
     // 30일 지난 휴지통 버블 목록
     @Query("SELECT b from Bubble b where b.updatedAt < :expiryDate and b.isTrashed = true")
     List<Bubble> findAllByUpdatedAtBeforeAndIsTrashedTrue(@Param("expiryDate") LocalDateTime expiryDate);
+
+    Set<Bubble> findAllByMemberAndLocalIdxIn(Member member, Set<Long> localIdxs);
+    Optional<Bubble> findByMemberAndLocalIdx(Member member, Long localIdx);
+    Boolean existsByMemberAndLocalIdx(Member member, Long localIdx);
 
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -21,7 +21,7 @@ import java.util.Set;
 public interface BubbleRepository extends JpaRepository<Bubble, Long> {
 
     // 삭제되지 않은 Bubble만 조회
-    Optional<Bubble> findByBubbleIdAndIsTrashedFalse(Long bubbleId);
+    Optional<Bubble> findByMember_MemberIdAndLocalIdxAndIsTrashedFalse(Long memberId, Long localIdx);
 
     Page<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId, Pageable pageable);
     Page<Bubble> findByMember_MemberIdAndIsTrashedTrue(Long memberId, Pageable pageable);

--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -34,10 +34,6 @@ public interface BubbleRepository extends JpaRepository<Bubble, Long> {
             Pageable pageable
     );
 
-    // 30일 지난 휴지통 버블 목록
-    @Query("SELECT b from Bubble b where b.updatedAt < :expiryDate and b.isTrashed = true")
-    List<Bubble> findAllByUpdatedAtBeforeAndIsTrashedTrue(@Param("expiryDate") LocalDateTime expiryDate);
-
     Set<Bubble> findAllByMemberAndLocalIdxIn(Member member, Set<Long> localIdxs);
     Optional<Bubble> findByMemberAndLocalIdx(Member member, Long localIdx);
     Boolean existsByMemberAndLocalIdx(Member member, Long localIdx);

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleService.java
@@ -20,9 +20,5 @@ public interface BubbleService {
 
     ResponseEntity<ApiResponse> getRecentBubblesByMember(CustomUserPrincipal userPrincipal, Pageable pageable);
 
-    ResponseEntity<ApiResponse> searchBubbles(CustomUserPrincipal userPrincipal, String keyword, boolean recent, Pageable pageable);
-
-    void deleteExpiredBubble();
-
     BubbleResponseDto.SyncResultDto syncBubble(CustomUserPrincipal userPrincipal, BubbleRequestDto.SyncDto requestDto);
 }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -62,7 +62,7 @@ public class BubbleServiceImpl implements BubbleService {
                 .collect(Collectors.toList());
 
         return BubbleResponseDto.SyncResultDto.builder()
-                .bubbleId(bubble.getBubbleId())
+                .localIdx(bubble.getLocalIdx())
                 .title(bubble.getTitle())
                 .content(bubble.getContent())
                 .mainImageUrl(bubble.getMainImg())
@@ -131,7 +131,7 @@ public class BubbleServiceImpl implements BubbleService {
                             .collect(Collectors.toList());
 
                     return BubbleResponseDto.TrashedListResultDto.builder()
-                            .bubbleId(bubble.getBubbleId())
+                            .localIdx(bubble.getLocalIdx())
                             .title(bubble.getTitle())
                             .content(bubble.getContent())
                             .mainImageUrl(bubble.getMainImg())
@@ -321,7 +321,7 @@ public class BubbleServiceImpl implements BubbleService {
                 .labels(mapLabelsToDto(labels))
                 .backlinkIds(bubble.getBacklinks().stream()
                         .map(BubbleBacklink::getBacklinkBubble)
-                        .map(Bubble::getBubbleId)
+                        .map(Bubble::getLocalIdx)
                         .collect(Collectors.toSet()))
                 .isDeleted(false)
                 .isTrashed(bubble.isTrashed())

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -178,17 +178,13 @@ public class BubbleServiceImpl implements BubbleService {
 
 
     @Override
-    public BubbleResponseDto.SyncResultDto getBubble(CustomUserPrincipal userPrincipal, Long bubbleId) {
+    public BubbleResponseDto.SyncResultDto getBubble(CustomUserPrincipal userPrincipal, Long localIdx) {
         if (userPrincipal == null) {
             throw new GeneralException(ErrorStatus.LOGIN_REQUIRED);
         }
 
-        Bubble bubble = bubbleRepository.findByBubbleIdAndIsTrashedFalse(bubbleId).orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
-
-        // 조회 권한 확인
-        if (!bubble.getMember().getMemberId().equals(userPrincipal.getMemberId())) {
-            throw new GeneralException(ErrorStatus._FORBIDDEN);
-        }
+        Bubble bubble = bubbleRepository.findByMember_MemberIdAndLocalIdxAndIsTrashedFalse(userPrincipal.getMemberId(), localIdx)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.BUBBLE_NOT_FOUND));
 
         return convertToBubbleResponseDto(bubble);
     }

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -67,9 +67,9 @@ public class BubbleServiceImpl implements BubbleService {
                 .content(bubble.getContent())
                 .mainImageUrl(bubble.getMainImg())
                 .labels(labelDtos)
-                .backlinkIds(bubble.getBacklinks().stream()
+                .backlinkIdxs(bubble.getBacklinks().stream()
                         .map(BubbleBacklink::getBacklinkBubble)
-                        .map(Bubble::getBubbleId)
+                        .map(Bubble::getLocalIdx)
                         .collect(Collectors.toSet()))
                 .isTrashed(bubble.isTrashed())
                 .createdAt(bubble.getCreatedAt())
@@ -113,13 +113,11 @@ public class BubbleServiceImpl implements BubbleService {
         PageInfo pageInfo = new PageInfo(bubblePage.getNumber(), bubblePage.getSize(), bubblePage.hasNext(),
                 bubblePage.getTotalElements(), bubblePage.getTotalPages());
 
-        // Bubble 데이터 변환
-        // Bubble -> DeletedListResultDto 변환
         List<BubbleResponseDto.TrashedListResultDto> bubbles = bubblePage.getContent().stream()
                 .map(bubble -> {
-                    LocalDateTime updatedAt = bubble.getUpdatedAt();
+                    LocalDateTime deletedAt = bubble.getDeletedAt();
                     LocalDateTime now = LocalDateTime.now();
-                    long remainDays = 30 - ChronoUnit.DAYS.between(updatedAt, now);
+                    long remainDays = 30 - ChronoUnit.DAYS.between(deletedAt, now);
 
                     // 라벨 정보 변환
                     List<LabelResponseDTO.LabelSimpleInfoDto> labelDtos = bubble.getLabels().stream()
@@ -136,12 +134,13 @@ public class BubbleServiceImpl implements BubbleService {
                             .content(bubble.getContent())
                             .mainImageUrl(bubble.getMainImg())
                             .labels(labelDtos) // 라벨 정보 추가
-                            .backlinkIds(bubble.getBacklinks().stream()
+                            .backlinkIdxs(bubble.getBacklinks().stream()
                                     .map(BubbleBacklink::getBacklinkBubble)
-                                    .map(Bubble::getBubbleId)
+                                    .map(Bubble::getLocalIdx)
                                     .collect(Collectors.toSet()))
                             .createdAt(bubble.getCreatedAt())
-                            .updatedAt(updatedAt)
+                            .updatedAt(bubble.getUpdatedAt())
+                            .deletedAt(bubble.getDeletedAt())
                             .remainDay((int) Math.max(remainDays, 0)) // 남은 일수 계산
                             .build();
                 })
@@ -301,7 +300,7 @@ public class BubbleServiceImpl implements BubbleService {
                     .content(request.getContent())
                     .mainImageUrl(request.getMainImageUrl())
                     .labels(mapLabelsToDtoByLocalIdx(member, request.getLabelIdxs()))
-                    .backlinkIds(request.getBacklinkIds())
+                    .backlinkIdxs(request.getBacklinkIds())
                     .isDeleted(true)
                     .isTrashed(request.isTrashed())
                     .createdAt(request.getCreatedAt())
@@ -319,7 +318,7 @@ public class BubbleServiceImpl implements BubbleService {
                 .content(bubble.getContent())
                 .mainImageUrl(bubble.getMainImg())
                 .labels(mapLabelsToDto(labels))
-                .backlinkIds(bubble.getBacklinks().stream()
+                .backlinkIdxs(bubble.getBacklinks().stream()
                         .map(BubbleBacklink::getBacklinkBubble)
                         .map(Bubble::getLocalIdx)
                         .collect(Collectors.toSet()))

--- a/project/src/main/java/com/edison/project/domain/label/entity/Label.java
+++ b/project/src/main/java/com/edison/project/domain/label/entity/Label.java
@@ -15,6 +15,8 @@ import java.util.*;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder(toBuilder = true)
+@Table(name = "Label", indexes = {
+        @Index(name = "idx_localIdx", columnList = "local_idx")})
 public class Label {
 
     @Id

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -98,7 +98,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
                 .collect(Collectors.toList());
 
         return BubbleResponseDto.SyncResultDto.builder()
-                .bubbleId(bubble.getBubbleId())
+                .localIdx(bubble.getLocalIdx())
                 .title(bubble.getTitle())
                 .content(bubble.getContent())
                 .mainImageUrl(bubble.getMainImg())

--- a/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/label/service/LabelQueryServiceImpl.java
@@ -103,7 +103,7 @@ public class LabelQueryServiceImpl implements LabelQueryService {
                 .content(bubble.getContent())
                 .mainImageUrl(bubble.getMainImg())
                 .labels(labelDtos) // 라벨 정보 리스트
-                .backlinkIds(bubble.getBacklinks().stream()
+                .backlinkIdxs(bubble.getBacklinks().stream()
                         .map(BubbleBacklink::getBacklinkBubble)
                         .map(Bubble::getBubbleId)
                         .collect(Collectors.toSet()))


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #146 

## 📝 작업 내용

**버블 로직 수정**
> - logic
>     - SYNC, 조회 등 모든 API에서 서버 DB의 id 값이 아닌 서버 DB의 local_idx 값(즉 사용자 로컬 DB의 pk 값)을 사용하도록 수정
>     - 버블을 조회할 때 member와 local_idx 값으로 찾으므로 권한 검증 로직 삭제


**QA**
> 중복되는 코드 분리

수정된 API
- 버블 SYNC
- 버블 검색
- 버블 리스트 조회 (전체, 7일 이내, 상세정보)

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 수정된 API 가 모두 잘 돌아가는 지, localIdx값으로 잘 작동하고 저장되는 지 확인해주세요
