### PR TITLE
❕ [!HOTFIX] #160 전체(휴지통포함으로) 버블 조회 api 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -26,6 +26,9 @@ public interface BubbleRepository extends JpaRepository<Bubble, Long> {
     Page<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId, Pageable pageable);
     Page<Bubble> findByMember_MemberIdAndIsTrashedTrue(Long memberId, Pageable pageable);
 
+    // 휴지통에 있는 버블 포함 조회
+    Page<Bubble> findByMember_MemberId(Long memberId, Pageable pageable);
+
     // 7일 이내 버블 목록
     @Query("SELECT b from Bubble b where b.member.memberId = :memberId AND b.isDeleted = false AND b.updatedAt >= :startDate")
     Page <Bubble> findRecentBubblesByMember(

--- a/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/service/BubbleServiceImpl.java
@@ -77,7 +77,7 @@ public class BubbleServiceImpl implements BubbleService {
     @Transactional
     public ResponseEntity<ApiResponse> getBubblesByMember(CustomUserPrincipal userPrincipal, Pageable pageable) {
 
-        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberIdAndIsTrashedFalse(userPrincipal.getMemberId(), pageable);
+        Page<Bubble> bubblePage = bubbleRepository.findByMember_MemberId(userPrincipal.getMemberId(), pageable);
 
         PageInfo pageInfo = new PageInfo(bubblePage.getNumber(), bubblePage.getSize(), bubblePage.hasNext(),
                 bubblePage.getTotalElements(), bubblePage.getTotalPages());


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #160 

## 📝 작업 내용

> 버블 조회 api 휴지통에 있는 애들도 조회되도록 수정했습니다.

### 📸 스크린샷 (선택)
<img width="561" alt="스크린샷 2025-02-20 오전 2 05 43" src="https://github.com/user-attachments/assets/616b4f42-c294-4f41-896d-80ed41b33e1d" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
