### PR TITLE
✨ [FEAT] #165 아트레터 - 최근검색어 로직 구현

### DIFF
--- a/project/src/main/java/com/edison/project/common/exception/ExceptionAdvice.java
+++ b/project/src/main/java/com/edison/project/common/exception/ExceptionAdvice.java
@@ -56,6 +56,6 @@ public class ExceptionAdvice {
 
     @ExceptionHandler({MethodArgumentTypeMismatchException.class, ConversionFailedException.class})
     public ResponseEntity<ApiResponse> handleConversionFailedException(Exception e) {
-        return ApiResponse.onFailure((ErrorStatus.NOT_EXISTS_CATEGORY));
+        return ApiResponse.onFailure((ErrorStatus._BAD_REQUEST));
     }
 }

--- a/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
+++ b/project/src/main/java/com/edison/project/common/status/ErrorStatus.java
@@ -74,6 +74,7 @@ public enum ErrorStatus {
     INVALID_ARTLETTER_REQUEST(HttpStatus.BAD_REQUEST, "LETTER4014", "아트레터 ID는 1~3개만 요청할 수 있습니다."),
     DUPLICATE_ARTLETTER_IDS(HttpStatus.BAD_REQUEST, "LETTER4015", "중복된 아트레터 요청입니다."),
     THUMBNAIL_VALIDATION(HttpStatus.BAD_REQUEST, "LETTER4016", "썸네일은 null일 수 없습니다."),
+    MEMORY_KEYWORD_NOT_FOUND(HttpStatus.BAD_REQUEST, "LETTER4017", "존재하지 않는 검색어 입니다."),
 
     // 검색 관련 에러
     INVALID_KEYWORD(HttpStatus.BAD_REQUEST, "SEARCH4001", "검색어는 공백일 수 없습니다."),

--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -153,4 +153,19 @@ public class ArtletterController {
         Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return artletterService.getScrapCategoryArtletters(userPrincipal, category, pageable);
     }
+
+    // 최근 검색어 조회
+    @GetMapping("/search-memory")
+    public ResponseEntity<ApiResponse> getMemoryMemory(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
+        return artletterService.getMemoryKeyword(userPrincipal);
+    }
+
+    // 최근 검색어 삭제
+    @DeleteMapping("/search-memory")
+    public ResponseEntity<ApiResponse> deleteMemoryKeyword(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @RequestBody ArtletterDTO.MemoryKeywordRequestDto request) {
+        return artletterService.deleteMemoryKeyword(userPrincipal, request);
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
@@ -169,5 +169,19 @@ public class ArtletterDTO {
         private LocalDateTime updatedAt;
     }
 
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemoryKeywordRequestDto {
+        private String keyword;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class MemoryKeywordResponseDto {
+        private List<String> keywords;
+    }
+
 }
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -15,6 +15,9 @@ public interface ArtletterService {
     ResponseEntity<ApiResponse> searchArtletters(CustomUserPrincipal userPrincipal, String keyword, int page, int size, String sortType);
     ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId);
 
+    ResponseEntity<ApiResponse> getMemoryKeyword(CustomUserPrincipal userPrincipal);
+    ResponseEntity<ApiResponse> deleteMemoryKeyword(CustomUserPrincipal userPrincipal, ArtletterDTO.MemoryKeywordRequestDto request);
+
     ArtletterDTO.LikeResponseDto likeToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId);
     ArtletterDTO.ScrapResponseDto scrapToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId);
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -13,6 +13,8 @@ import com.edison.project.domain.artletter.entity.ArtletterLikes;
 import com.edison.project.domain.artletter.repository.ArtletterLikesRepository;
 import com.edison.project.domain.artletter.repository.ArtletterRepository;
 import com.edison.project.domain.member.entity.Member;
+import com.edison.project.domain.member.entity.MemberMemory;
+import com.edison.project.domain.member.repository.MemberMemoryRepository;
 import com.edison.project.domain.member.repository.MemberRepository;
 import com.edison.project.domain.scrap.entity.Scrap;
 import com.edison.project.domain.scrap.repository.ScrapRepository;
@@ -37,8 +39,10 @@ public class ArtletterServiceImpl implements ArtletterService {
 
     private final ArtletterRepository artletterRepository;
     private final MemberRepository memberRepository;
+    private final MemberMemoryRepository memberMemoryRepository;
     private final ArtletterLikesRepository artletterLikesRepository;
     private final ScrapRepository scrapRepository;
+    private final Map<Long, LinkedList<String>> recentSearchKeywords = new HashMap<>();
 
 
     // 전체 아트레터 조회 API
@@ -91,6 +95,7 @@ public class ArtletterServiceImpl implements ArtletterService {
                 .createdAt(savedArtletter.getCreatedAt())
                 .build();
     }
+
 
 
     // 아트레터 좋아요 토글 api
@@ -168,6 +173,7 @@ public class ArtletterServiceImpl implements ArtletterService {
 
     // 아트레터 검색 api
     @Override
+    @Transactional
     public ResponseEntity<ApiResponse> searchArtletters(CustomUserPrincipal userPrincipal, String keyword, int page, int size, String sortType) {
         Member member = getMemberIfAuthenticated(userPrincipal);
 
@@ -176,12 +182,18 @@ public class ArtletterServiceImpl implements ArtletterService {
 
         PageInfo pageInfo = buildPageInfo(resultPage);
 
-        List<Artletter> sortedResults = sortSearchResults(resultPage.getContent(), keyword); // ✅ 키워드 기반 정렬 유지
+        List<Artletter> sortedResults = sortSearchResults(resultPage.getContent(), keyword);
         List<ArtletterDTO.SimpleArtletterResponseDto> response = sortedResults.stream()
                 .map(artletter -> buildSimpleListResponseDto(artletter, member))
                 .collect(Collectors.toList());
 
         response = sortArtletters(response, sortType);
+
+        // 🔥 추가된 부분: 최근 검색어 저장
+        if (member != null && keyword != null && !keyword.trim().isEmpty()) {
+            saveMemoryKeyword(member, keyword);
+        }
+
         return ApiResponse.onSuccess(SuccessStatus._OK, pageInfo, response);
     }
 
@@ -195,6 +207,72 @@ public class ArtletterServiceImpl implements ArtletterService {
                 )
                 .collect(Collectors.toList());
     }
+
+    // 최근 검색어 자동 저장 메서드
+    private void saveMemoryKeyword(Member member, String memory) {
+        // 올바른 메서드 사용
+        List<MemberMemory> memories = memberMemoryRepository.findMemberMemoriesByMemberId(member.getMemberId());
+
+        // 이미 존재하는 메모리 삭제
+        memories.stream()
+                .filter(existingMemory -> existingMemory.getMemory().equals(memory))
+                .findFirst()
+                .ifPresent(memberMemoryRepository::delete);
+
+        // 최대 3개 유지, 오래된 것부터 삭제
+        if (memories.size() >= 3) {
+            memories.sort(Comparator.comparing(MemberMemory::getCreatedAt));
+            memberMemoryRepository.delete(memories.get(0));
+        }
+
+        // 새로운 메모리 추가
+        MemberMemory newMemory = MemberMemory.builder()
+                .member(member)
+                .memory(memory)
+                .build();
+
+        memberMemoryRepository.save(newMemory);
+    }
+
+
+
+
+    // 최근 검색어 조회
+    @Override
+    @Transactional
+    public ResponseEntity<ApiResponse> getMemoryKeyword(CustomUserPrincipal userPrincipal) {
+        Long memberId = userPrincipal.getMemberId();
+
+        List<String> memories = memberMemoryRepository.findMemoriesByMemberId(memberId);
+
+        ArtletterDTO.MemoryKeywordResponseDto response = new ArtletterDTO.MemoryKeywordResponseDto(memories);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
+
+    // 최근 검색어 삭제
+// 최근 검색어 삭제
+    @Override
+    @Transactional
+    public ResponseEntity<ApiResponse> deleteMemoryKeyword(CustomUserPrincipal userPrincipal, ArtletterDTO.MemoryKeywordRequestDto request) {
+        Long memberId = userPrincipal.getMemberId();
+        String keyword = request.getKeyword() != null ? request.getKeyword().trim() : null;
+
+        if (keyword == null || keyword.isEmpty()) {
+            throw new GeneralException(ErrorStatus.MEMORY_KEYWORD_NOT_FOUND);
+        }
+
+        // 데이터베이스를 통해 검색어 존재 여부 확인
+        int deletedCount = memberMemoryRepository.deleteByMemberIdAndMemory(memberId, keyword);
+
+        if (deletedCount == 0) {
+            throw new GeneralException(ErrorStatus.MEMORY_KEYWORD_NOT_FOUND);
+        }
+
+        return ApiResponse.onSuccess(SuccessStatus._OK);
+    }
+
+
 
 
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -51,7 +51,7 @@ public class ArtletterServiceImpl implements ArtletterService {
         Page<Artletter> artletters = getPaginatedArtletters(page, size);
         PageInfo pageInfo = buildPageInfo(artletters);
 
-        Member member = getMemberIfAuthenticated(userPrincipal);
+        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
 
         List<ArtletterDTO.SimpleArtletterResponseDto> response = artletters.getContent().stream()
                 .map(artletter -> buildSimpleListResponseDto(artletter, member))
@@ -70,8 +70,6 @@ public class ArtletterServiceImpl implements ArtletterService {
     // 아트레터 등록 api
     @Override
     public ArtletterDTO.CreateResponseDto createArtletter(CustomUserPrincipal userPrincipal, ArtletterDTO.CreateRequestDto request) {
-
-        Member member = findMemberById(userPrincipal.getMemberId());
 
         Artletter artletter = Artletter.builder()
                 .title(request.getTitle())
@@ -103,7 +101,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Transactional
     public ArtletterDTO.LikeResponseDto likeToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId) {
 
-        Member member = findMemberById(userPrincipal.getMemberId());
+        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
         Artletter artletter = findArtletterById(letterId);
         boolean alreadyLiked = artletterLikesRepository.existsByMemberAndArtletter(member, artletter);
 
@@ -141,7 +139,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Transactional
     public ArtletterDTO.ScrapResponseDto scrapToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId) {
 
-        Member member = findMemberById(userPrincipal.getMemberId());
+        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
         Artletter artletter = findArtletterById(letterId);
         boolean alreadyScrapped = scrapRepository.existsByMemberAndArtletter(member, artletter);
 
@@ -175,7 +173,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     @Transactional
     public ResponseEntity<ApiResponse> searchArtletters(CustomUserPrincipal userPrincipal, String keyword, int page, int size, String sortType) {
-        Member member = getMemberIfAuthenticated(userPrincipal);
+        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
 
         Pageable pageable = PageRequest.of(page, size);
         Page<Artletter> resultPage = artletterRepository.searchByKeyword(keyword, pageable);
@@ -327,7 +325,7 @@ public class ArtletterServiceImpl implements ArtletterService {
         }
 
         Member member = Optional.ofNullable(userPrincipal)
-                .map(up -> findMemberById(up.getMemberId()))
+                .map(up -> memberRepository.findByMemberId(up.getMemberId()))
                 .orElse(null);
 
         List<Long> artletterIds = editorRequestDto.getArtletterIds();
@@ -415,7 +413,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     public ResponseEntity<ApiResponse> getScrapArtlettersByCategory(CustomUserPrincipal userPrincipal, Pageable pageable) {
 
-        Member member = findMemberById(userPrincipal.getMemberId());
+        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
 
         Page<Scrap> scraps = scrapRepository.findByMember(member, pageable);
 
@@ -456,7 +454,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     public ResponseEntity<ApiResponse> getScrapCategoryArtletters(CustomUserPrincipal userPrincipal, ArtletterCategory category, Pageable pageable) {
 
-        Member member = findMemberById(userPrincipal.getMemberId());
+        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
 
         try {
             ArtletterCategory artletterCategory = ArtletterCategory.valueOf(String.valueOf(category));
@@ -498,20 +496,6 @@ public class ArtletterServiceImpl implements ArtletterService {
     /*
     공통 메서드 모음
     */
-
-    // 로그인 여부 확인 후 Member 조회
-    private Member getMemberIfAuthenticated(CustomUserPrincipal userPrincipal) {
-        if (userPrincipal == null) {
-            return null;
-        }
-        return memberRepository.findById(userPrincipal.getMemberId()).orElse(null);
-    }
-
-    // Member 존재 여부 조회
-    private Member findMemberById(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
-    }
 
     // Artletter 존재 여부 조회
     private Artletter findArtletterById(Long letterId) {

--- a/project/src/main/java/com/edison/project/domain/member/entity/Member.java
+++ b/project/src/main/java/com/edison/project/domain/member/entity/Member.java
@@ -8,7 +8,9 @@ import lombok.*;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 @Getter
 @Setter
@@ -48,6 +50,9 @@ public class  Member extends BaseEntity {
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Label> labels = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MemberMemory> memoryMemories = new ArrayList<>();
 
     public Member(String email) {
         super();

--- a/project/src/main/java/com/edison/project/domain/member/entity/MemberMemory.java
+++ b/project/src/main/java/com/edison/project/domain/member/entity/MemberMemory.java
@@ -1,0 +1,45 @@
+package com.edison.project.domain.member.entity;
+
+import com.edison.project.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
+import java.util.Date;
+
+@Entity
+@Builder
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class MemberMemory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "memory_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+
+    @Column(name = "memory", nullable = false)
+    private String memory;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = true)
+    private LocalDateTime updatedAt;
+}
+
+
+
+
+
+

--- a/project/src/main/java/com/edison/project/domain/member/repository/MemberMemoryRepository.java
+++ b/project/src/main/java/com/edison/project/domain/member/repository/MemberMemoryRepository.java
@@ -1,0 +1,27 @@
+package com.edison.project.domain.member.repository;
+
+import com.edison.project.domain.member.entity.MemberMemory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface MemberMemoryRepository extends JpaRepository<MemberMemory, Long> {
+
+    // 메모리 문자열만 반환
+    @Query("SELECT m.memory FROM MemberMemory m WHERE m.member.memberId = :memberId ORDER BY m.createdAt DESC")
+    List<String> findMemoriesByMemberId(@Param("memberId") Long memberId);
+
+    // MemberMemory 엔티티 자체를 반환
+    @Query("SELECT m FROM MemberMemory m WHERE m.member.memberId = :memberId ORDER BY m.createdAt DESC")
+    List<MemberMemory> findMemberMemoriesByMemberId(@Param("memberId") Long memberId);
+
+    // 키워드 삭제 쿼리 추가
+    @Modifying
+    @Query("DELETE FROM MemberMemory m WHERE m.member.memberId = :memberId AND m.memory = :memory")
+    int deleteByMemberIdAndMemory(@Param("memberId") Long memberId, @Param("memory") String memory);
+
+}
+

--- a/project/src/main/java/com/edison/project/domain/member/repository/MemberRepository.java
+++ b/project/src/main/java/com/edison/project/domain/member/repository/MemberRepository.java
@@ -2,7 +2,10 @@ package com.edison.project.domain.member.repository;
 
 import com.edison.project.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {

--- a/project/src/main/java/com/edison/project/domain/member/repository/MemberRepository.java
+++ b/project/src/main/java/com/edison/project/domain/member/repository/MemberRepository.java
@@ -2,10 +2,7 @@ package com.edison.project.domain.member.repository;
 
 import com.edison.project.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
-import java.util.List;
 import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
@@ -13,4 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
     boolean existsByMemberId(Long memberId);
     void deleteByMemberId(Long memeberId);
+    Member findByMemberId(Long memberId);
 }

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -50,7 +50,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             );
 
             if (authHeader == null){
-                if (method.equals("GET") && requestURI.startsWith("/artletters")&& !requestURI.contains("scrap")) {
+                if (method.equals("GET") && requestURI.startsWith("/artletters")
+                        && !requestURI.contains("scrap") && !requestURI.contains("search-memory")) {
                     filterChain.doFilter(request, response);
                     return;
                 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

>close #165 

## 📝 작업 내용

> 아트레터 - 최근검색어 저장/조회/삭제 로직을 구현하였습니다.
> 최근 검색어 저장은 아트레터 검색 시 저장됩니다!
> 최근 검색어 로직은 로그인이 필요합니다

### 📸 스크린샷 (선택)
<img width="677" alt="image" src="https://github.com/user-attachments/assets/62e2c33e-aa20-499d-bdbd-265cc8c38916" />
<img width="649" alt="image" src="https://github.com/user-attachments/assets/8b2ed86a-5310-4b18-b06f-f22a48fd6758" />

## 💬 리뷰 요구사항(선택)
 
**현재 코드가 쫌 더러운데, 코드 불 필요한 부분 있으면 그냥 브랜치 들어가서 바로 지워주시면 감사하겟습니다,,,,,,ㅠㅜ**

> 1. 검색 시 검색어 저장 잘 되는지(최근 3개까지)
> 2. 검색 조회 잘 되는지(최근 검색어를 먼저 반환하도록 함)
> 3. 검색 삭제 잘 되는지(db에서도 잘 삭제되는지)
> 4. 이외의 필요한 검증 사항,,,


조회 : get, localhost:8080/artletters/search-memory
삭제 : delete, localhost:8080/artletters/search-memory
(삭제 request body: 
{
    "keyword": "문학"
})
