### PR TITLE
❕ [HOTFIX] #170 아트레터 최근 검색어 삭제 query params로 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -19,7 +19,6 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
-import java.util.Map;
 
 @RestController
 @RequestMapping("/artletters")
@@ -165,7 +164,7 @@ public class ArtletterController {
     @DeleteMapping("/search-memory")
     public ResponseEntity<ApiResponse> deleteMemoryKeyword(
             @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
-            @RequestBody ArtletterDTO.MemoryKeywordRequestDto request) {
-        return artletterService.deleteMemoryKeyword(userPrincipal, request);
+            @RequestParam(value = "keyword", required = false) String keyword) {
+        return artletterService.deleteMemoryKeyword(userPrincipal, keyword);
     }
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -16,7 +16,7 @@ public interface ArtletterService {
     ArtletterDTO.ListResponseDto getArtletter(CustomUserPrincipal userPrincipal, long letterId);
 
     ResponseEntity<ApiResponse> getMemoryKeyword(CustomUserPrincipal userPrincipal);
-    ResponseEntity<ApiResponse> deleteMemoryKeyword(CustomUserPrincipal userPrincipal, ArtletterDTO.MemoryKeywordRequestDto request);
+    ResponseEntity<ApiResponse> deleteMemoryKeyword(CustomUserPrincipal userPrincipal, String keyword);
 
     ArtletterDTO.LikeResponseDto likeToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId);
     ArtletterDTO.ScrapResponseDto scrapToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId);

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -249,12 +249,12 @@ public class ArtletterServiceImpl implements ArtletterService {
 
 
     // 최근 검색어 삭제
-// 최근 검색어 삭제
     @Override
     @Transactional
-    public ResponseEntity<ApiResponse> deleteMemoryKeyword(CustomUserPrincipal userPrincipal, ArtletterDTO.MemoryKeywordRequestDto request) {
+    public ResponseEntity<ApiResponse> deleteMemoryKeyword(CustomUserPrincipal userPrincipal, String keyword) {
         Long memberId = userPrincipal.getMemberId();
-        String keyword = request.getKeyword() != null ? request.getKeyword().trim() : null;
+
+        keyword = keyword != null ? keyword.trim() : null;
 
         if (keyword == null || keyword.isEmpty()) {
             throw new GeneralException(ErrorStatus.MEMORY_KEYWORD_NOT_FOUND);


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #170 

## 📝 작업 내용

> 아트레터 최근 검색어 삭제 api의 request를 body값이 아니라 query parmas로 받도록 수정하였습니다.

### 📸 스크린샷 (선택)
<img width="655" alt="image" src="https://github.com/user-attachments/assets/621b1014-165a-4ed4-84ee-e8a714ff0118" />

## 💬 리뷰 요구사항(선택)

> localhost:8080/artletters/search-memory?keyword=기술과학
