### PR TITLE
❕ [HOTFIX] #170 아트레터 검색, 조회 api 로그인 없을 때 에러 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -51,7 +51,7 @@ public class ArtletterServiceImpl implements ArtletterService {
         Page<Artletter> artletters = getPaginatedArtletters(page, size);
         PageInfo pageInfo = buildPageInfo(artletters);
 
-        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
+        Member member = getMemberIfAuthenticated(userPrincipal);
 
         List<ArtletterDTO.SimpleArtletterResponseDto> response = artletters.getContent().stream()
                 .map(artletter -> buildSimpleListResponseDto(artletter, member))
@@ -173,7 +173,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     @Transactional
     public ResponseEntity<ApiResponse> searchArtletters(CustomUserPrincipal userPrincipal, String keyword, int page, int size, String sortType) {
-        Member member = memberRepository.findByMemberId(userPrincipal.getMemberId());
+        Member member = getMemberIfAuthenticated(userPrincipal);
 
         Pageable pageable = PageRequest.of(page, size);
         Page<Artletter> resultPage = artletterRepository.searchByKeyword(keyword, pageable);
@@ -496,6 +496,13 @@ public class ArtletterServiceImpl implements ArtletterService {
     /*
     공통 메서드 모음
     */
+
+    private Member getMemberIfAuthenticated(CustomUserPrincipal userPrincipal) {
+        if (userPrincipal == null) {
+            return null;
+        }
+        return memberRepository.findById(userPrincipal.getMemberId()).orElse(null);
+    }
 
     // Artletter 존재 여부 조회
     private Artletter findArtletterById(Long letterId) {


### PR DESCRIPTION
## 📝 작업 내용

> 아트레터 관련 api 로그인 안 했을 때 생기는 에러 수정했습니다!

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 아트레터 조회, 검색 로그인없이 되는지 확인해주세요!
