### PR TITLE
✨ [FEAT] #169 : 아트레터 카테고리별 조회 API 설계, close #169

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -168,4 +168,16 @@ public class ArtletterController {
             @RequestBody ArtletterDTO.MemoryKeywordRequestDto request) {
         return artletterService.deleteMemoryKeyword(userPrincipal, request);
     }
+
+    // 카테고리별 아트레터 조회
+    @GetMapping("/category")
+    public ResponseEntity<ApiResponse> getArtlettersByCategory(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @RequestParam("category") ArtletterCategory category,
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "20") int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        return artletterService.getArtlettersByCategory(userPrincipal, category, pageable);
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
@@ -183,5 +183,17 @@ public class ArtletterDTO {
         private List<String> keywords;
     }
 
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class CategoryResponseDto {
+        private Long artletterId;
+        private String title;
+        private String thumbnail;
+        private String tags;
+        private boolean isScraped;
+    }
+
 }
 

--- a/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepository.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepository.java
@@ -2,6 +2,9 @@ package com.edison.project.domain.artletter.repository;
 
 import com.edison.project.domain.artletter.dto.CountDto;
 import com.edison.project.domain.artletter.entity.Artletter;
+import com.edison.project.domain.artletter.entity.ArtletterCategory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
@@ -11,5 +14,8 @@ import java.util.List;
 @Repository
 public interface ArtletterRepository extends JpaRepository<Artletter, Long>, ArtletterRepositoryCustom {
     List<Artletter> findByLetterIdIn(List<Long> letterIds);
+
+    Page<Artletter> findByCategory(ArtletterCategory category, Pageable pageable);
+
 }
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -3,6 +3,7 @@ package com.edison.project.domain.artletter.service;
 import com.edison.project.common.response.ApiResponse;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.entity.ArtletterCategory;
+import com.edison.project.domain.member.entity.Member;
 import com.edison.project.global.security.CustomUserPrincipal;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -29,5 +30,5 @@ public interface ArtletterService {
     ResponseEntity<ApiResponse> getScrapCategoryArtletters(CustomUserPrincipal userPrincipal, ArtletterCategory category, Pageable pageable);
 
     ArtletterDTO.CreateResponseDto createArtletter(CustomUserPrincipal userPrincipal, ArtletterDTO.CreateRequestDto request);
-
+    ResponseEntity<ApiResponse> getArtlettersByCategory(CustomUserPrincipal userPrincipal, ArtletterCategory category, Pageable pageable);
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -584,11 +584,11 @@ public class ArtletterServiceImpl implements ArtletterService {
                 artletters.getTotalPages()
         );
 
-        List<ArtletterDTO.ListResponseDto> response = artletters.getContent().stream()
+        List<ArtletterDTO.CategoryResponseDto> response = artletters.getContent().stream()
                 .map(artletter -> {
-                    boolean isScrapped = (member != null)git && scrapRepository.existsByMemberAndArtletter(member, artletter);
+                    boolean isScrapped = (member != null) && scrapRepository.existsByMemberAndArtletter(member, artletter);
 
-                    return ArtletterDTO.ListResponseDto.builder()
+                    return ArtletterDTO.CategoryResponseDto.builder()
                             .artletterId(artletter.getLetterId())
                             .title(artletter.getTitle())
                             .thumbnail(artletter.getThumbnail())

--- a/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
+++ b/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
@@ -34,5 +34,4 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     @Query("SELECT new com.edison.project.domain.artletter.dto.CountDto(a.artletter.letterId, COUNT(a)) " +
             "FROM ArtletterLikes a WHERE a.artletter IN :artletters GROUP BY a.artletter")
     List<CountDto> countByArtletterIn(@Param("artletters") List<Artletter> artletters);
-
 }


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) #169 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
아트레터 카테고리별로 조회하는 api 설계하였습니다.

### 📸 스크린샷 (선택)
![image](https://github.com/user-attachments/assets/874facb9-5352-47d3-af82-5b70d13ebbd0)



## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
> 로그인 되지 않았을 시 scraped = false 나오고, 로그인되었을땐 잘 나오는지 확인해주세요!
