### PR TITLE
[REFACTOR] #182: 아트레터 검색 native query 도입 정렬 로직 DB로 이동, close #182

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepositoryCustomImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepositoryCustomImpl.java
@@ -17,31 +17,30 @@ public class ArtletterRepositoryCustomImpl implements ArtletterRepositoryCustom 
 
     @Override
     public Page<Artletter> searchByKeyword(String keyword, Pageable pageable) {
-        String queryStr = """
-        SELECT a FROM Artletter a
-        WHERE a.tag LIKE :keyword 
-        OR a.title LIKE :keyword 
-        OR a.content LIKE :keyword
-    """;
+        // Full-Text Search 기반 relevance 정렬
+        String nativeQueryStr = """
+            SELECT *, MATCH(tag, title, content) AGAINST (:keyword IN BOOLEAN MODE) AS relevance
+            FROM artletter
+            WHERE MATCH(tag, title, content) AGAINST (:keyword IN BOOLEAN MODE)
+            ORDER BY relevance DESC
+            LIMIT :limit OFFSET :offset
+        """;
 
         String countQueryStr = """
-        SELECT COUNT(a) FROM Artletter a
-        WHERE a.tag LIKE :keyword 
-        OR a.title LIKE :keyword 
-        OR a.content LIKE :keyword
-    """;
+            SELECT COUNT(*) FROM artletter
+            WHERE MATCH(tag, title, content) AGAINST (:keyword IN BOOLEAN MODE)
+        """;
 
-        TypedQuery<Artletter> query = entityManager.createQuery(queryStr, Artletter.class);
-        TypedQuery<Long> countQuery = entityManager.createQuery(countQueryStr, Long.class);
+        List<Artletter> resultList = entityManager.createNativeQuery(nativeQueryStr, Artletter.class)
+                .setParameter("keyword", keyword + "*")  // 부분 매치 지원
+                .setParameter("limit", pageable.getPageSize())
+                .setParameter("offset", pageable.getOffset())
+                .getResultList();
 
-        query.setParameter("keyword", "%" + keyword + "%");
-        countQuery.setParameter("keyword", "%" + keyword + "%");
+        Number totalCount = (Number) entityManager.createNativeQuery(countQueryStr)
+                .setParameter("keyword", keyword + "*")
+                .getSingleResult();
 
-        long totalRows = countQuery.getSingleResult();
-        query.setFirstResult((int) pageable.getOffset());
-        query.setMaxResults(pageable.getPageSize());
-
-        return new PageImpl<>(query.getResultList(), pageable, totalRows);
+        return new PageImpl<>(resultList, pageable, totalCount.longValue());
     }
-
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -528,28 +528,6 @@ public class ArtletterServiceImpl implements ArtletterService {
                 .build();
     }
 
-    // 아트레터 스크랩/좋아요/최신순 정렬
-    private List<ArtletterDTO.SimpleArtletterResponseDto> sortArtletters(List<ArtletterDTO.SimpleArtletterResponseDto> artletters, String sortType) {
-        return switch (sortType) {
-            case "likes" -> artletters.stream()
-                    .sorted(Comparator.comparing(ArtletterDTO.SimpleArtletterResponseDto::getLikesCnt)
-                            .reversed())
-                    .toList();
-
-            case "scraps" -> artletters.stream()
-                    .sorted(Comparator
-                            .comparing(ArtletterDTO.SimpleArtletterResponseDto::getScrapsCnt).reversed()
-                            .thenComparing(ArtletterDTO.SimpleArtletterResponseDto::getUpdatedAt).reversed()
-                            .thenComparing(ArtletterDTO.SimpleArtletterResponseDto::getLikesCnt).reversed())
-                    .toList();
-
-            case "latest" -> artletters.stream()
-                    .sorted(Comparator.comparing(ArtletterDTO.SimpleArtletterResponseDto::getUpdatedAt).reversed())
-                    .toList();
-
-            default -> artletters;
-        };
-    }
 
     // 추천바 - 아트레터 요청 검증
     private List<Artletter> validateArtletterIds(List<Long> artletterIds) {


### PR DESCRIPTION

## #⃣ 연관된 이슈

> ex) #182 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
1. like 기반 검색에서 full-text search 기반 검색으로 변경했습니다.
→ 대용량 데이터에서 성능 향상 효과 및 부분 단어의 매칭을 지원합니다. 
2. 검색 정렬 로직을 변경했습니다!
→ 기존 검색 결과를 가져온 뒤에 java 단에서 정렬하는 메서드(sortSearchResults, sortArtletters)를 제거하며 Pageable의 sort 기능을 통하여 DB 쿼리에서 정렬 가능하도록 하였습니다. 
→ 코드 간결화 및 유지보수?

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
