### PR TITLE
refactor #194: 아트레터 에디터픽 랜덤 조회 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -84,12 +84,11 @@ public class ArtletterController {
     }
 
 
-    @PostMapping("/editor-pick")
+    @GetMapping("/editor-pick")
     public ResponseEntity<ApiResponse> getEditorArtletters(
-            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
-            @RequestBody ArtletterDTO.EditorRequestDto editorRequestDto) {
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal) {
 
-        return artletterService.getEditorArtletters(userPrincipal, editorRequestDto);
+        return artletterService.getEditorArtletters(userPrincipal);
     }
   
 

--- a/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
@@ -56,14 +56,6 @@ public class ArtletterDTO {
     @Builder
     @AllArgsConstructor
     @NoArgsConstructor
-    public static class EditorRequestDto {
-        private List<Long> artletterIds;
-    }
-
-    @Data
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
     public static class CreateResponseDto {
         private Long artletterId;
         private String title;

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -22,7 +22,7 @@ public interface ArtletterService {
     ArtletterDTO.LikeResponseDto likeToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId);
     ArtletterDTO.ScrapResponseDto scrapToggleArtletter(CustomUserPrincipal userPrincipal, Long letterId);
 
-    ResponseEntity<ApiResponse> getEditorArtletters(CustomUserPrincipal userPrincipal, ArtletterDTO.EditorRequestDto editorRequestDto);
+    ResponseEntity<ApiResponse> getEditorArtletters(CustomUserPrincipal userPrincipal);
     List<ArtletterDTO.recommendKeywordDto> getRecommendKeyword(List<Long> artletterIds);
     List<String> getRecommendCategory();
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -312,45 +312,35 @@ public class ArtletterServiceImpl implements ArtletterService {
     }
 
     @Override
-    public ResponseEntity<ApiResponse> getEditorArtletters(CustomUserPrincipal userPrincipal, ArtletterDTO.EditorRequestDto editorRequestDto) {
-        if (editorRequestDto == null || editorRequestDto.getArtletterIds() == null || editorRequestDto.getArtletterIds().isEmpty()) {
-            throw new GeneralException(ErrorStatus.ARTLETTER_ID_REQUIRED);
-        }
+    public ResponseEntity<ApiResponse> getEditorArtletters(CustomUserPrincipal userPrincipal) {
 
         Member member = Optional.ofNullable(userPrincipal)
                 .map(up -> memberRepository.findByMemberId(up.getMemberId()))
                 .orElse(null);
 
-        List<Long> artletterIds = editorRequestDto.getArtletterIds();
-        List<Artletter> artletters = artletterRepository.findByLetterIdIn(artletterIds);
+        // 전체 아트레터 중 랜덤 3개 조회
+        List<Artletter> allArtletters = artletterRepository.findAll();
 
-        if (artletters.size() < artletterIds.size()) {
-            Set<Long> foundArtletterIds = artletters.stream()
-                    .map(Artletter::getLetterId)
-                    .collect(Collectors.toSet());
+        // 랜덤 3개 추출
+        Collections.shuffle(allArtletters);
+        List<Artletter> selected = allArtletters.subList(0, 3);
 
-            for (Long artletterId : artletterIds) {
-                if (!foundArtletterIds.contains(artletterId)) {
-                    throw new GeneralException(ErrorStatus.LETTERS_NOT_FOUND, "요청된 아트레터가 존재하지 않습니다. (ID: " + artletterId + ")");
-                }
-            }
-        }
 
-        Map<Long, Boolean> likedMap = artletterLikesRepository.findByMemberAndArtletterIn(member, artletters)
+        Map<Long, Boolean> likedMap = artletterLikesRepository.findByMemberAndArtletterIn(member, selected)
                 .stream().collect(Collectors.toMap(al -> al.getArtletter().getLetterId(), al -> true));
 
-        Map<Long, Boolean> scrappedMap = scrapRepository.findByMemberAndArtletterIn(member, artletters)
+        Map<Long, Boolean> scrappedMap = scrapRepository.findByMemberAndArtletterIn(member, selected)
                 .stream().collect(Collectors.toMap(sc -> sc.getArtletter().getLetterId(), sc -> true));
 
-        Map<Long, Integer> likesCountMap = artletterLikesRepository.countByArtletterIn(artletters)
+        Map<Long, Integer> likesCountMap = artletterLikesRepository.countByArtletterIn(selected)
                 .stream()
                 .collect(Collectors.toMap(CountDto::getArtletterId, countDto -> countDto.getCount().intValue()));
 
-        Map<Long, Integer> scrapsCountMap = scrapRepository.countByArtletterIn(artletters)
+        Map<Long, Integer> scrapsCountMap = scrapRepository.countByArtletterIn(selected)
                 .stream()
                 .collect(Collectors.toMap(CountDto::getArtletterId, countDto -> countDto.getCount().intValue()));
 
-        List<ArtletterDTO.ListResponseDto> artletterList = artletters.stream()
+        List<ArtletterDTO.ListResponseDto> artletterList = selected.stream()
                 .map(artletter -> ArtletterDTO.ListResponseDto.builder()
                         .artletterId(artletter.getLetterId())
                         .title(artletter.getTitle())


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) close #194 

## 📝 작업 내용

> 에디터픽 아트레터 랜덤으로 3개 조회 되도록 수정했습니다.

### 📸 스크린샷 (선택)
<img width="705" alt="스크린샷 2025-05-30 오후 1 15 05" src="https://github.com/user-attachments/assets/542935ae-7373-47a5-b7a9-f319814a1b03" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
