### PR TITLE
✨[FEAT] #209: doc2vec 데이터셋 생성 openAI API 구현

### DIFF
--- a/project/src/main/java/com/edison/project/domain/space/controller/SpaceController.java
+++ b/project/src/main/java/com/edison/project/domain/space/controller/SpaceController.java
@@ -34,6 +34,13 @@ public class SpaceController {
         return ApiResponse.onSuccess(SuccessStatus._OK, space);
     }
 
+    // 데이터셋 생성 openAPI
+    @PostMapping("/generate")
+    public ResponseEntity<ApiResponse> generateSentence(@RequestParam(defaultValue = "poetic") String type) {
+        String sentence = spaceService.generateAndSave(type);
+        return ApiResponse.onSuccess(SuccessStatus._OK, sentence);
+    }
+
     /*
     @PostMapping("/convert")
     public ResponseEntity<?> convertSelectedSpaces(
@@ -53,6 +60,6 @@ public class SpaceController {
         List<SpaceResponseDto> spaces = (List<SpaceResponseDto>) response.getBody().getResult();
         return ApiResponse.onSuccess(SuccessStatus._OK, spaces);
     }
-    
+
      */
 }

--- a/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
+++ b/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
@@ -18,7 +18,11 @@ public class Dataset {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
-    public Dataset(String content) {
+    @Column(name = "category")
+    private String category;
+
+    public Dataset(String content, String category) {
         this.content = content;
+        this.category = category;
     }
 }

--- a/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
+++ b/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
@@ -1,9 +1,6 @@
 package com.edison.project.domain.space.entity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -18,6 +15,7 @@ public class Dataset {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
     public Dataset(String content) {

--- a/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
+++ b/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
@@ -19,4 +19,8 @@ public class Dataset {
     private Long id;
 
     private String content;
+
+    public Dataset(String content) {
+        this.content = content;
+    }
 }

--- a/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
+++ b/project/src/main/java/com/edison/project/domain/space/entity/Dataset.java
@@ -1,0 +1,22 @@
+package com.edison.project.domain.space.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+public class Dataset {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String content;
+}

--- a/project/src/main/java/com/edison/project/domain/space/repository/DatasetRepository.java
+++ b/project/src/main/java/com/edison/project/domain/space/repository/DatasetRepository.java
@@ -1,0 +1,9 @@
+package com.edison.project.domain.space.repository;
+
+import com.edison.project.domain.space.entity.Dataset;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DatasetRepository extends JpaRepository<Dataset, Long> {
+}

--- a/project/src/main/java/com/edison/project/domain/space/service/SpaceService.java
+++ b/project/src/main/java/com/edison/project/domain/space/service/SpaceService.java
@@ -1,15 +1,13 @@
 package com.edison.project.domain.space.service;
 
-import com.edison.project.common.response.ApiResponse;
 import com.edison.project.domain.space.dto.SpaceMapResponseDto;
 import com.edison.project.global.security.CustomUserPrincipal;
-import org.springframework.data.domain.Pageable;
-import org.springframework.http.ResponseEntity;
 
 import java.util.List;
 
 public interface SpaceService {
     List<SpaceMapResponseDto.MapResponseDto> mapBubbles(CustomUserPrincipal userPrincipal);
+    String generateAndSave(String type);
     //ResponseEntity<ApiResponse> processSpaces(CustomUserPrincipal userPrincipal, List<String> localIdxs, String userIdentityKeywords);
     //ResponseEntity<ApiResponse> processSpaces(CustomUserPrincipal userPrincipal, Pageable pageable, String userIdentityKeywords);
 

--- a/project/src/main/java/com/edison/project/domain/space/service/SpaceServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/space/service/SpaceServiceImpl.java
@@ -111,18 +111,20 @@ public class SpaceServiceImpl implements SpaceService {
     @Transactional
     public String generateAndSave(String type) {
         String prompt = switch (type) {
-            case "poem" -> "앞서 얘기했던 것과 겹치지 않는 내용의 감성적인 시 한 편을 생성해줘.";
-            case "novel" -> "앞서 얘기했던 것과 겹치지 않는 내용의 감성적인 소설 문장을 한 문단 써줘.";
-            case "science" -> "앞서 얘기했던 것과 겹치지 않는 새로운 분야의 과학적 사실 내용을 한 문단 써줘.";
-            case "diary" -> "앞서 얘기했던 것과 겹치지 않게 일상적 일기나 대화를 한 문단 써줘.";
-            case "direct" -> "앞서 얘기했던 것과 겹치지 않는 연출, 아이디어, 영감에 대한 내용을 한 문단 써줘.";
-            case "art" -> "앞서 얘기했던 것과 겹치지 않게 예술과 관련된 모든 분야의 내용 중 흥미로운 내용을 한 문단 써줘.";
-            case "recent" -> "앞서 얘기했던 것과 겹치지 않게 현재 이슈가 되고 있는 내용들에 대한 사실들로 한 문단 써줘. 정치적 내용 제외하고";
-            default -> "앞대답과는 다른 내용의 감성적이고 아름다운 문장을 여러 줄 생성해줘.";
+            case "poem" -> "앞서 얘기했던 것과 절대 겹치지 않는 내용의 감성적인 시 한 편을 생성해줘. 밤이나 바다는 쓰지마.";
+            case "novel" -> "앞서 얘기했던 것과 절대 겹치지 않는 내용의 감성적인 소설 문장을 한 문단 써줘. 밤이나 바다는 쓰지마.";
+            case "science" -> "앞서 얘기했던 것과 절대 겹치지 않는 새로운 분야의 과학적 사실 내용을 한 문단 써줘. 우주에 대한 내용은 쓰지마.";
+            case "diary" -> "앞서 얘기했던 것과 절대 겹치지 않게 일상적 메모나 대화를 한 문단 써줘. 특이한 일상에 대한 메모였으면 좋겠어.";
+            case "direct" -> "앞서 얘기했던 것과 절대 겹치지 않는 연출, 아이디어, 영감에 대한 내용을 한 문단 써줘. 특정 분야에 대한 내용을 자세하게 써줘도 좋아.";
+            case "art" -> "앞서 얘기했던 것과 절대 겹치지 않게 예술과 관련된 내용 중 흥미로운 내용을 한 문단 써줘. 특정 분야에 대한 내용을 자세하게 써줘도 좋아.";
+            case "recent" -> "앞서 얘기했던 것과 절대 겹치지 않고 현재 이슈가 되고 있는 내용들에 대한 사실들로 한 문단 써줘. 코로나19와 정치적 환경적 내용 제외하고";
+            case "culture" -> "앞서 얘기했던 것과 절대 겹치지 않게 다른 나라 문화에 대한 사실들로 한 문단 써줘. 정치적 내용 제외하고 특정 문화에 대한 내용을 자세하게 써줘도 좋아.";
+            case "dataset" -> "앞서 얘기했던 것과 절대 겹치지 않게 doc2vec 모델에 사전학습할 문장들로 한 문단 써줘.";
+            default -> "앞서 얘기했던 것과 절대 겹치지 않는 내용의 감성적이고 아름다운 문장을 여러 줄 생성해줘. 밤이나 바다는 쓰지마.";
         };
 
         String sentence = callOpenAPI(prompt);
-        datasetRepository.save(new Dataset(sentence));
+        datasetRepository.save(new Dataset(sentence, type));
         return sentence;
     }
 

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -55,6 +55,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/artletters/recommend-bar/category").permitAll() // 추천 카테고리
                         .requestMatchers(HttpMethod.GET, "/artletters/recommend-bar/keyword").permitAll() // 추천 키워드
                         .requestMatchers(HttpMethod.POST, "/artletters/editor-pick").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/spaces/generate").permitAll()
 
                         .anyRequest().authenticated()
                 )

--- a/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
+++ b/project/src/main/java/com/edison/project/global/security/JwtAuthenticationFilter.java
@@ -46,7 +46,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                     "/favicon.ico",
                     "/artletters/recommend-bar/category",
                     "/artletters/recommend-bar/keyword",
-                    "/artletters/editor-pick"
+                    "/artletters/editor-pick",
+                    "/spaces/generate"
             );
 
             if (authHeader == null){


### PR DESCRIPTION
## #⃣ 연관된 이슈

> close #209 

## 📝 작업 내용

- space 기능에서 사용할 doc2vec AI 모델을 사전학습 시키기 위해 필요한 데이터셋을 구축해주는 API입니다.
- 예술, 연출, 최근이슈, 일상, 과학, 문화, 소설 등 다양한 카테고리의 메모를 생성 받아 DB에 저장합니다.
- Security Config 및 Chain에서 제외해두었기 때문에 토큰 없이 접근 가능합니다.
- 프롬프트는 초안이므로 아직 개선해야 합니다.

### 📸 스크린샷 (선택)
<img width="676" alt="image" src="https://github.com/user-attachments/assets/936b13e9-4a48-4e16-91b3-9e16d625269a" />
<img width="683" alt="image" src="https://github.com/user-attachments/assets/ed3234ee-f1d5-4130-a1b7-ab1d31a597eb" />

## 💬 리뷰 요구사항(선택)

