### PR TITLE
[FEAT] #216: 현재 아트레터 제외 랜덤 추천 API 설계, closes #216

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/controller/ArtletterController.java
@@ -131,6 +131,15 @@ public class ArtletterController {
         return ApiResponse.onSuccess(SuccessStatus._OK, response);
     }
 
+    @GetMapping("/more/{currentId}")
+    public ResponseEntity<ApiResponse> getRandomArtletters(
+            @AuthenticationPrincipal CustomUserPrincipal userPrincipal,
+            @PathVariable("currentId") Long currentId) {
+
+        List<ArtletterDTO.CategoryResponseDto> response = artletterService.getOtherArtletters(userPrincipal, currentId);
+        return ApiResponse.onSuccess(SuccessStatus._OK, response);
+    }
+
     @GetMapping("/scrap")
     @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResponse> getScrapArtletters(

--- a/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepository.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/repository/ArtletterRepository.java
@@ -17,5 +17,7 @@ public interface ArtletterRepository extends JpaRepository<Artletter, Long>, Art
 
     Page<Artletter> findByCategory(ArtletterCategory category, Pageable pageable);
 
+    @Query("SELECT a.letterId FROM Artletter a")
+    List<Long> findAllIds();
 }
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterService.java
@@ -31,4 +31,6 @@ public interface ArtletterService {
 
     ArtletterDTO.CreateResponseDto createArtletter(CustomUserPrincipal userPrincipal, ArtletterDTO.CreateRequestDto request);
     ResponseEntity<ApiResponse> getArtlettersByCategory(CustomUserPrincipal userPrincipal, ArtletterCategory category, Pageable pageable);
+
+    List<ArtletterDTO.CategoryResponseDto> getOtherArtletters(CustomUserPrincipal userPrincipal, Long currentId);
 }

--- a/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
+++ b/project/src/main/java/com/edison/project/domain/scrap/repository/ScrapRepository.java
@@ -34,4 +34,6 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     @Query("SELECT new com.edison.project.domain.artletter.dto.CountDto(a.artletter.letterId, COUNT(a)) " +
             "FROM ArtletterLikes a WHERE a.artletter IN :artletters GROUP BY a.artletter")
     List<CountDto> countByArtletterIn(@Param("artletters") List<Artletter> artletters);
+
+    boolean existsByArtletterAndMemberAndDeletedAtIsNull(Artletter artletter, Member member);
 }

--- a/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
+++ b/project/src/main/java/com/edison/project/global/config/SecurityConfig.java
@@ -58,6 +58,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/spaces/generate").permitAll()
                         .requestMatchers("/api/s3/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
+                        .requestMatchers("/artletters/more").permitAll()
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #216

## 📝 작업 내용

> 아트레터 읽고 나서 하단에 현재 아트레터를 제외한 다른 아트레터를 랜덤으로 3개 띄워주는 api를 설계했습니다.

<img width="1373" height="794" alt="image" src="https://github.com/user-attachments/assets/6c982a02-446e-4f8d-bfec-263373d38a49" />

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
