### PR TITLE
🚧 [REFACTOR] #231 아트레터 조회시 작가 정보도 같이 반환되도록 수정

### DIFF
--- a/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/dto/ArtletterDTO.java
@@ -34,9 +34,9 @@ public class ArtletterDTO {
         @NotNull(message = "category는 null일 수 없습니다.")
         private ArtletterCategory category;
 
-        @NotBlank(message = "writer는 비어있을 수 없습니다.")
-        @Pattern(regexp = "^[a-zA-Z가-힣\\s]+$", message = "writer는 문자만 허용됩니다.")
-        private String writer;
+        @NotNull(message = "writerId는 비어있을 수 없습니다.")
+        @Positive(message = "writerId는 양수여야 합니다.")
+        private Long writerId;
 
         @NotNull(message = "readTime은 0보다 큰 정수여야 합니다.")
         @Min(value = 1, message = "readTime은 0보다 큰 정수여야 합니다.")
@@ -48,14 +48,6 @@ public class ArtletterDTO {
         @NotNull(message = "thumbnail은 null일 수 없습니다.")
         private String thumbnail;
 
-    }
-
-    @Data
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class EditorRequestDto {
-        private List<Long> artletterIds;
     }
 
     @Data
@@ -82,7 +74,7 @@ public class ArtletterDTO {
         private String content;
         private ArtletterCategory category;
         private int readTime;
-        private String writer;
+        private WriterSummaryDto writerSummary;
         private String tags;
         private String thumbnail;
         private int likesCnt;
@@ -170,13 +162,6 @@ public class ArtletterDTO {
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
-    public static class MemoryKeywordRequestDto {
-        private String keyword;
-    }
-
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
     public static class MemoryKeywordResponseDto {
         private List<String> keywords;
     }
@@ -191,6 +176,17 @@ public class ArtletterDTO {
         private String thumbnail;
         private String tags;
         private boolean isScraped;
+    }
+
+    @Data
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class WriterSummaryDto {
+        private Long writerId;
+        private String writerName;
+        private String profileImg;
+        private String writerUrl;
     }
 
 }

--- a/project/src/main/java/com/edison/project/domain/artletter/entity/Artletter.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/entity/Artletter.java
@@ -26,8 +26,10 @@ public class Artletter extends BaseEntity {
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;
 
-    @Column(name = "writer", length = 100)
-    private String writer;
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "writer_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_artletter_writer"))
+    private Writer writer;
 
     @Column(name = "read_time", nullable = false)
     private int readTime;

--- a/project/src/main/java/com/edison/project/domain/artletter/entity/Writer.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/entity/Writer.java
@@ -1,0 +1,32 @@
+package com.edison.project.domain.artletter.entity;
+
+import com.edison.project.global.common.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "writer")
+public class Writer extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "writer_id")
+    private Long writerId;
+
+    @Column(name = "writer_name")
+    private String writerName;
+
+    @Column(name = "profile_img")
+    private String profileImg;
+
+    @Column(name = "writer_url")
+    private String writerUrl;
+
+}

--- a/project/src/main/java/com/edison/project/domain/artletter/repository/WriterRepository.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/repository/WriterRepository.java
@@ -1,0 +1,9 @@
+package com.edison.project.domain.artletter.repository;
+
+
+import com.edison.project.domain.artletter.entity.Writer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WriterRepository extends JpaRepository<Writer, Long> {
+
+}

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -7,13 +7,11 @@ import com.edison.project.common.status.ErrorStatus;
 import com.edison.project.common.status.SuccessStatus;
 import com.edison.project.domain.artletter.dto.ArtletterDTO;
 import com.edison.project.domain.artletter.dto.CountDto;
-import com.edison.project.domain.artletter.entity.Artletter;
-import com.edison.project.domain.artletter.entity.ArtletterCategory;
-import com.edison.project.domain.artletter.entity.ArtletterLikes;
-import com.edison.project.domain.artletter.entity.EditorPick;
+import com.edison.project.domain.artletter.entity.*;
 import com.edison.project.domain.artletter.repository.ArtletterLikesRepository;
 import com.edison.project.domain.artletter.repository.ArtletterRepository;
 import com.edison.project.domain.artletter.repository.EditorPickRepository;
+import com.edison.project.domain.artletter.repository.WriterRepository;
 import com.edison.project.domain.member.entity.Member;
 import com.edison.project.domain.member.entity.MemberMemory;
 import com.edison.project.domain.member.repository.MemberMemoryRepository;
@@ -33,7 +31,6 @@ import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 
 @Slf4j
 @Service
@@ -46,6 +43,7 @@ public class ArtletterServiceImpl implements ArtletterService {
     private final ArtletterLikesRepository artletterLikesRepository;
     private final ScrapRepository scrapRepository;
     private final EditorPickRepository editorPickRepository;
+    private final WriterRepository writerRepository;
 
     // 전체 아트레터 조회 API
     @Override
@@ -73,10 +71,13 @@ public class ArtletterServiceImpl implements ArtletterService {
     @Override
     public ArtletterDTO.CreateResponseDto createArtletter(CustomUserPrincipal userPrincipal, ArtletterDTO.CreateRequestDto request) {
 
+        Writer writer = writerRepository.getReferenceById(request.getWriterId());
+        // 존재 여부 보장 안해도 되니까 .. 레퍼런스 썻어요
+
         Artletter artletter = Artletter.builder()
                 .title(request.getTitle())
                 .content(request.getContent())
-                .writer(request.getWriter())
+                .writer(writer)
                 .readTime(request.getReadTime())
                 .tag(request.getTag())
                 .category(request.getCategory())
@@ -291,7 +292,7 @@ public class ArtletterServiceImpl implements ArtletterService {
                 .title(artletter.getTitle())
                 .content(artletter.getContent())
                 .tags(artletter.getTag())
-                .writer(artletter.getWriter())
+                .writerSummary( toWriterSummaryDto(artletter.getWriter()) )
                 .category(artletter.getCategory())
                 .readTime(artletter.getReadTime())
                 .thumbnail(artletter.getThumbnail())
@@ -338,7 +339,7 @@ public class ArtletterServiceImpl implements ArtletterService {
                         .title(artletter.getTitle())
                         .content(artletter.getContent())
                         .tags(artletter.getTag())
-                        .writer(artletter.getWriter())
+                        .writerSummary( toWriterSummaryDto(artletter.getWriter()) )
                         .category(artletter.getCategory())
                         .readTime(artletter.getReadTime())
                         .thumbnail(artletter.getThumbnail())
@@ -353,6 +354,16 @@ public class ArtletterServiceImpl implements ArtletterService {
 
 
         return artletterList;
+    }
+
+    private ArtletterDTO.WriterSummaryDto toWriterSummaryDto(Writer w) {
+        if (w == null) return null;
+        return ArtletterDTO.WriterSummaryDto.builder()
+                .writerId(w.getWriterId())
+                .writerName(w.getWriterName())
+                .profileImg(w.getProfileImg())
+                .writerUrl(w.getWriterUrl())
+                .build();
     }
 
 

--- a/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
+++ b/project/src/main/java/com/edison/project/domain/artletter/service/ArtletterServiceImpl.java
@@ -72,7 +72,6 @@ public class ArtletterServiceImpl implements ArtletterService {
     public ArtletterDTO.CreateResponseDto createArtletter(CustomUserPrincipal userPrincipal, ArtletterDTO.CreateRequestDto request) {
 
         Writer writer = writerRepository.getReferenceById(request.getWriterId());
-        // 존재 여부 보장 안해도 되니까 .. 레퍼런스 썻어요
 
         Artletter artletter = Artletter.builder()
                 .title(request.getTitle())


### PR DESCRIPTION
## #⃣ 연관된 이슈

> #231 

## 📝 작업 내용

> 아트레터 상세조회시 작가 정보 반환하도록 했습니다. DTO 따로 만들어놨습니다....!! DB도 수정햇어욤

### 📸 스크린샷 (선택)

<img width="812" height="634" alt="image" src="https://github.com/user-attachments/assets/41abf07e-008d-4a90-a3a7-059105f8501b" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
