### PR TITLE
[REFACTOR] n+1 관련 문제 해결

### DIFF
--- a/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
+++ b/project/src/main/java/com/edison/project/domain/bubble/repository/BubbleRepository.java
@@ -1,13 +1,11 @@
 package com.edison.project.domain.bubble.repository;
 
 import com.edison.project.domain.bubble.entity.Bubble;
-import com.edison.project.domain.label.entity.Label;
 import com.edison.project.domain.member.entity.Member;
-import jakarta.transaction.Transactional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -20,25 +18,50 @@ import java.util.Set;
 @Repository
 public interface BubbleRepository extends JpaRepository<Bubble, Long> {
 
+    // ============ 단건 조회 ============
     Optional<Bubble> findByMember_MemberIdAndLocalIdxAndIsTrashedFalse(Long memberId, String localIdx);
     Optional<Bubble> findByMember_MemberIdAndLocalIdxAndIsTrashedTrue(Long memberId, String localIdx);
+    Optional<Bubble> findByMemberAndLocalIdx(Member member, String localIdx);
 
-    List<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId);
+    // 단건 상세 조회 (연관관계 함께 로딩)
+    @EntityGraph(attributePaths = {"labels", "labels.label", "backlinks", "backlinks.backlinkBubble"})
+    @Query("SELECT b FROM Bubble b " +
+            "WHERE b.member.memberId = :memberId " +
+            "AND b.localIdx = :localIdx " +
+            "AND b.isTrashed = false")
+    Optional<Bubble> findByMemberAndLocalIdxWithDetails(
+            @Param("memberId") Long memberId,
+            @Param("localIdx") String localIdx
+    );
+
+    // ============ 목록 조회 (페이징) ============
+
+    // 전체 버블 (휴지통 제외)
     Page<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId, Pageable pageable);
+
+    // 휴지통 버블
     Page<Bubble> findByMember_MemberIdAndIsTrashedTrue(Long memberId, Pageable pageable);
 
+    // 전체 버블 (휴지통 포함)
     Page<Bubble> findByMember_MemberId(Long memberId, Pageable pageable);
 
-    // 7일 이내 버블 목록
-    @Query("SELECT b from Bubble b where b.member.memberId = :memberId AND b.isDeleted = false AND b.updatedAt >= :startDate")
-    Page <Bubble> findRecentBubblesByMember(
+    // 최근 7일 버블
+    @Query("SELECT b FROM Bubble b " +
+            "WHERE b.member.memberId = :memberId " +
+            "AND b.isTrashed = false " +
+            "AND b.updatedAt >= :since")
+    Page<Bubble> findRecentByMember(
             @Param("memberId") Long memberId,
-            @Param("startDate") LocalDateTime startDate,
+            @Param("since") LocalDateTime since,
             Pageable pageable
     );
 
-    Set<Bubble> findAllByMemberAndLocalIdxIn(Member member, Set<String> localIdxs);
-    Optional<Bubble> findByMemberAndLocalIdx(Member member, String localIdx);
-    Boolean existsByMemberAndLocalIdx(Member member, String localIdx);
+    // ============ 목록 조회 (리스트) ============
+    List<Bubble> findByMember_MemberIdAndIsTrashedFalse(Long memberId);
 
+    // ============ 배치 조회 ============
+    Set<Bubble> findAllByMemberAndLocalIdxIn(Member member, Set<String> localIdxs);
+
+    // ============ 존재 여부 ============
+    Boolean existsByMemberAndLocalIdx(Member member, String localIdx);
 }

--- a/project/src/main/resources/application.properties
+++ b/project/src/main/resources/application.properties
@@ -10,6 +10,7 @@ spring.datasource.password=${RDS_PASSWORD}
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.properties.hibernate.default_batch_fetch_size=100
 spring.jpa.database-platform=org.hibernate.dialect.MySQL8Dialect
 
 # JPA Console Log


### PR DESCRIPTION
## #⃣ 연관된 이슈

> ex) #239  

## 📝 작업 내용
1. BatchSize 기반 N+1 문제 해결
- application.yml에 default_batch_fetch_size: 100 설정 추가
- 기존 Fetch Join 쿼리 제거 → IN절 배치 조회하도록 변경했습니다.

2. @Transactional 정리
- 클래스 레벨에 @Transactional(readOnly = true) 적용
- 쓰기 작업 메서드에만 개별 @Transactional 명시

3. 단건 조회 최적화
findByMemberAndLocalIdxWithDetails에 @EntityGraph 적용했습니다!

4. convertToTrashedDto 이용한 코드 정리

### 📸 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)

- 휴지통 버블의 content 포함 여부는 PM님 확인해봤는데 내부에서 보인다고 합니다...............
- 부득이하게 이전 pr 브랜치를 잘못된 곳에서 작업하여 다시 수정하여 올립니다 ~!! ㅜㅜ 